### PR TITLE
県内発生件数が表示されない

### DIFF
--- a/utils/formatTestedCases.ts
+++ b/utils/formatTestedCases.ts
@@ -7,7 +7,7 @@ type DataType = {
       value: number
       children: [
         {
-          attr: '都内発生件数'
+          attr: '県内発生件数'
           value: number
         },
         {
@@ -22,7 +22,7 @@ type DataType = {
 type TestedCasesType = {
   累計人数: number
   合計件数: number
-  都内発生件数: number
+  県内発生件数: number
   その他件数: number
 }
 
@@ -35,7 +35,7 @@ export default (data: DataType) => {
   const formattedData: TestedCasesType = {
     累計人数: data.value,
     合計件数: data.children[0].value,
-    都内発生件数: data.children[0].children[0].value,
+    県内発生件数: data.children[0].children[0].value,
     その他件数: data.children[0].children[1].value
   }
   return formattedData


### PR DESCRIPTION
MeditationDuck/covid19 が issue 開放されていないので issue 無し

## 👏 解決する issue / Resolved Issues

- TestedCasesTable で 県内発生件数 が表示されない
- TestedCasesDetailsCard で 県内発生件数 が表示されない
- Data.inspection_status_summaryのラベル変更もれ

## ⛏ 変更内容 / Details of Changes

- data/data.json の inspection_status_summary の attr: "県内発生件数" に合うように utils/formatTestedCases の attr を修正

## 📸 スクリーンショット / Screenshots

Before  
<img width="470" alt="Screen Shot 2020-03-24 at 3 04 49 PM" src="https://user-images.githubusercontent.com/242669/77394339-70291b00-6de2-11ea-9535-e607a56f745a.png">

After  
<img width="470" alt="Screen Shot 2020-03-24 at 3 05 05 PM" src="https://user-images.githubusercontent.com/242669/77394361-7cad7380-6de2-11ea-8fb7-2a86f07f52e1.png">
