### PR TITLE
github のリポジトリへのリンクを岩手版に変更

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -182,7 +182,7 @@
         }}
         <i18n path="詳しくは、{githubRepo}をご確認ください。">
           <a
-            href="https://github.com/tokyo-metropolitan-gov/covid19"
+            href="https://github.com/MeditationDuck/covid19"
             target="_blank"
             rel="noopener"
             place="githubRepo"


### PR DESCRIPTION
MeditationDuck/covid19 が issue 開放されていないので issue 無し

## 👏 解決する issue / Resolved Issues
- /about のページのgithubリポジトリのURLが東京版のまま

## ⛏ 変更内容 / Details of Changes
- 岩手版のリポジトリURLに変更
