### PR TITLE
development modeの公開サイトURLを岩手版に修正

### DIFF
--- a/components/DevelopmentModeMark.vue
+++ b/components/DevelopmentModeMark.vue
@@ -1,11 +1,7 @@
 <template>
   <div v-if="isDevelopmentMode" class="DevelopmentModeMark">
     開発中（development mode）
-    <a
-      href="https://stopcovid19.metro.tokyo.lg.jp/"
-      target="_blank"
-      rel="noopener"
-    >
+    <a href="https://covid19-iwate.netlify.com/" target="_blank" rel="noopener">
       公開サイトへ
     </a>
   </div>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- 下部に表示されているの「公開サイトへ」のリンク先が東京都のサイトになっていた

## ⛏ 変更内容 / Details of Changes
- DevelopmentModeMark.vueで該当部分のリンク先を岩手県版のサイトに修正

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
<img width="1676" alt="スクリーンショット 2020-03-24 10 26 31" src="https://user-images.githubusercontent.com/4443492/77403561-b8046e00-6df3-11ea-8fd5-b27f144817d4.png">

