### PR TITLE
東京都のオープンデータサイトへのリンクを削除する

### DIFF
--- a/components/cards/ConsultationDeskReportsNumberCard.vue
+++ b/components/cards/ConsultationDeskReportsNumberCard.vue
@@ -7,7 +7,6 @@
       :chart-data="querentsGraph"
       :date="Data.querents.date"
       :unit="$t('件.reports')"
-      :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000070'"
     >
       <template v-slot:description>
         <ul>

--- a/components/cards/TelephoneAdvisoryReportsNumberCard.vue
+++ b/components/cards/TelephoneAdvisoryReportsNumberCard.vue
@@ -7,7 +7,6 @@
       :chart-data="contactsGraph"
       :date="Data.contacts.date"
       :unit="$t('件.reports')"
-      :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000071'"
     >
       <template v-slot:description>
         <ul>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #9

## ⛏ 変更内容 / Details of Changes
- 「【帰国者・接触者相談センター】受付 相談件数」「（一般相談）受付への相談件数」に東京都のオープンデータサイトへのリンクが表示されていたため，削除した

## 📸 スクリーンショット / Screenshots
<img width="546" alt="スクリーンショット 2020-03-25 18 08 49" src="https://user-images.githubusercontent.com/23148331/77519945-befab180-6ec3-11ea-9b17-da6b8d959cca.png">
<img width="548" alt="スクリーンショット 2020-03-25 18 08 56" src="https://user-images.githubusercontent.com/23148331/77519955-c1f5a200-6ec3-11ea-95b6-84817e918cba.png">
