### PR TITLE
twitter card summary_large_image の meta タグを生成する設定

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -34,6 +34,11 @@ const config: Configuration = {
         hid: 'og:image',
         property: 'og:image',
         content: 'https://covid19-iwate.netlify.com/ogp.png'
+      },
+      {
+        hid: 'twitter:card',
+        name: 'twitter:card',
+        content: 'summary_large_image'
       }
     ],
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #11

## ⛏ 変更内容 / Details of Changes
- nuxt.config.ts に twitter:card の設定を追加

## 📸 スクリーンショット / Screenshots

Before
<img width="709" alt="Screen Shot 2020-03-27 at 1 26 32 PM" src="https://user-images.githubusercontent.com/242669/77721584-a6f37100-702e-11ea-933e-8fd8e91b7eda.png">

After
<img width="709" alt="Screen Shot 2020-03-27 at 1 24 18 PM" src="https://user-images.githubusercontent.com/242669/77721596-ac50bb80-702e-11ea-9da6-34da0504079b.png">

