### PR TITLE
i18n_generator.py の None is not in list エラーへの対応

### DIFF
--- a/auto-i18n/i18n_generator.py
+++ b/auto-i18n/i18n_generator.py
@@ -157,7 +157,9 @@ with open(os.path.join(os.pardir, OUTPUT_DIR, CHECK_RESULT), mode="a", encoding=
                         # タグを統合し、重複分を取り除く
                         all_tags = list(set(all_tags + tags))
                     # Noneが混じっているので、取り除く
-                    all_tags.pop(all_tags.index(None))
+                    # all_tags.pop(all_tags.index(None))
+                    # ↑ 東京版のこのコードが動かないので ↓ で対応
+                    all_tags = [x for x in all_tags if x is not None]
                     # 全角のハイフン、半角のハイフン、全角のダッシュが混じっているので、取り除く
                     # 理由は components/cards/ConfirmedCasesAttributesCard.vue の75行目辺りを参照。
                     for x in ["-", "‐", "―"]:


### PR DESCRIPTION
https://github.com/MeditationDuck/covid19/issues/217
をとりあえず解消する

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #217 
