### PR TITLE
ConfirmedCasesDetailsTable で英語の場合 文字が溢れる

### DIFF
--- a/components/ConfirmedCasesDetailsTable.vue
+++ b/components/ConfirmedCasesDetailsTable.vue
@@ -257,6 +257,8 @@ $default-boxdiff: 35px;
   flex-direction: column;
   justify-content: flex-end;
   align-items: center;
+  overflow-wrap: break-word;
+  word-break: break-all;
 
   > span {
     display: block;


### PR DESCRIPTION
英語が単語の途中で改行されるようになるが、仕方ない。

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #412 

## 📝 関連する issue / Related Issues
- #0
- #0

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 英単語の途中でも改行が入るように css を調整

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

### Before
<img width="653" alt="Screen Shot 2020-08-08 at 12 51 46 AM" src="https://user-images.githubusercontent.com/242669/89664876-c1115a00-d912-11ea-9f2b-4ca6dfa6bbf4.png">
<img width="310" alt="Screen Shot 2020-08-08 at 12 53 49 AM" src="https://user-images.githubusercontent.com/242669/89664893-c66ea480-d912-11ea-957c-7fff88879733.png">

### After
<img width="653" alt="Screen Shot 2020-08-08 at 12 52 44 AM" src="https://user-images.githubusercontent.com/242669/89664922-d1293980-d912-11ea-94ce-2ec7b8b9915f.png">
<img width="310" alt="Screen Shot 2020-08-08 at 12 54 08 AM" src="https://user-images.githubusercontent.com/242669/89664943-dab2a180-d912-11ea-851d-4abfc1194e04.png">


