### PR TITLE
fix: PositiveRateCardの項目名を変更

### DIFF
--- a/components/cards/PositiveRateCard.vue
+++ b/components/cards/PositiveRateCard.vue
@@ -3,7 +3,7 @@
     <client-only>
       <positive-rate-mixed-chart
         :title-id="'positive-rate'"
-        :info-titles="[$t('検査の陽性率'), $t('検査件数')]"
+        :info-titles="[$t('検査の陽性率'), $t('PCR検査の7日間平均')]"
         :chart-id="'positive-rate-chart'"
         :chart-data="positiveRateGraph"
         :get-formatter="getFormatter"


### PR DESCRIPTION
weekly_average_diagnosed_count は PCR検査の7日間移動平均の数を表示する

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #454 
