### PR TITLE
fix: MonitoringConfirmedCasesNumberCard の title を変更

### DIFF
--- a/components/cards/MonitoringConfirmedCasesNumberCard.vue
+++ b/components/cards/MonitoringConfirmedCasesNumberCard.vue
@@ -3,7 +3,7 @@
     <client-only>
       <monitoring-confirmed-cases-chart
         title-id="monitoring-number-of-confirmed-cases"
-        :info-titles="[$t('新規陽性者数')]"
+        :info-titles="[$t('新規陽性者数の7日間平均')]"
         chart-id="monitoring-confirmed-cases-chart"
         :chart-data="chartData"
         :get-formatter="getFormatter"


### PR DESCRIPTION
新規陽性者数
から
新規陽性者数の7日間平均
に変更

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #461 
