### PR TITLE
個別の退院フラグを管理できないので、入院数・退院数を Google Sheets の output_hospitalized_numbers から計算する

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -27,7 +27,7 @@
             <td class="text-start">{{ item['居住地'] }}</td>
             <td class="text-start">{{ item['年代'] }}</td>
             <td class="text-start">{{ item['性別'] }}</td>
-            <td class="text-center">{{ item['退院'] }}</td>
+            <!-- <td class="text-center">{{ item['退院'] }}</td> -->
           </tr>
         </tbody>
       </template>

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -45,15 +45,15 @@ export default {
     }
 
     // 陽性者の属性 ヘッダー翻訳
-    for (const header of patientsTable.headers) {
-      header.text =
-        header.value === '退院' ? this.$t('退院※') : this.$t(header.value)
-    }
+    // for (const header of patientsTable.headers) {
+    //   header.text =
+    //     header.value === '退院' ? this.$t('退院※') : this.$t(header.value)
+    // }
     // 陽性者の属性 中身の翻訳
     for (const row of patientsTable.datasets) {
       row['居住地'] = this.getTranslatedWording(row['居住地'])
       row['性別'] = this.getTranslatedWording(row['性別'])
-      row['退院'] = this.getTranslatedWording(row['退院'])
+      // row['退院'] = this.getTranslatedWording(row['退院'])
 
       if (row['年代'].substr(-1, 1) === '代') {
         const age = row['年代'].substring(0, 2)

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -13,7 +13,7 @@ const headers: Header[] = [
   { text: '居住地', value: '居住地' },
   { text: '年代', value: '年代' },
   { text: '性別', value: '性別' },
-  { text: '退院※', value: '退院', align: 'center' },
+  // { text: '退院※', value: '退院', align: 'center' },
 ]
 
 type DataType = {
@@ -22,7 +22,7 @@ type DataType = {
   居住地: string | null
   年代: string | null
   性別: '男性' | '女性' | string
-  退院: '◯' | null
+  // 退院: '◯' | null
   [key: string]: any
 }
 
@@ -32,7 +32,7 @@ type TableDataType = {
   居住地: DataType['居住地']
   年代: DataType['年代']
   性別: DataType['性別'] | '不明'
-  退院: DataType['退院']
+  // 退院: DataType['退院']
 }
 
 type TableDateType = {
@@ -60,7 +60,7 @@ export default function (data: DataType[]): TableDateType {
         居住地: d['居住地'] ?? '調査中',
         年代: d['年代'] ?? '不明',
         性別: d['性別'] ?? '不明',
-        退院: d['退院'],
+        // 退院: d['退院'],
       }
     })
     .sort((a, b) => dayjs(a.公表日).unix() - dayjs(b.公表日).unix())


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #485 

## ⛏ 変更内容 / Details of Changes
- 「陽性者の属性」で個別事例の退院○印を非表示にする
- 岩手県が個別の症状（軽症・中症・重症）を発表していないのでカウントできない
- 岩手県が個別の退院日を公表していないので Google Sheets の output_patients からカウントできないので、 Google Sheets の output_hospitalized_numbers で手動管理する値を採用する

