### PR TITLE
github action で yarn run generate するときのタイムゾーンをTokyoに設定

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn run test
       - run: yarn run generate:deploy --fail-on-page-error
+        env:
+          TZ: 'Asia/Tokyo'
 
       - name: archive dist
         uses: actions/upload-artifact@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
           yarn run generate:deploy --fail-on-page-error
         env:
           GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+          TZ: 'Asia/Tokyo'
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ogp_builder.yml
+++ b/.github/workflows/ogp_builder.yml
@@ -34,6 +34,8 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn run test
       - run: yarn run generate:deploy
+        env:
+          TZ: 'Asia/Tokyo'
       - run: pip3 install selenium
       - run: (python3 -m http.server --directory ./dist 8000 &)  ; python3 ./ui-test/ogp_screenshot.py
       - name: Upload screenshot

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -32,6 +32,8 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn run test
       - run: yarn run generate:deploy
+        env:
+          TZ: 'Asia/Tokyo'
       - run: pip install selenium
       - run: (python -m http.server --directory ./dist 8000 &)  ; python ./ui-test/screenshot.py
       - name: Upload screenshot

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -31,6 +31,8 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn run test
       - run: yarn run generate:dev --fail-on-page-error
+        env:
+          TZ: 'Asia/Tokyo'
       - run: "echo \"User-agent: *\nDisallow: /\" > ./dist/robots.txt"
 
       - name: deploy


### PR DESCRIPTION
utils/formatDate.ts の .format(YYYY-MM-DD) などでJSTを前提にデータが用意されているのに、UTCで日付が計算されて、日付またぎが発生する

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #625 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

timezoneの問題で？

> 2020年9月4日の岩手県新型コロナウィルス最新状況は、陽性件数が1件・PCR検査が58件・抗原検査が15件・現在の入院患者は5人です。

になって欲しい部分が

> 2020年9月3日の岩手県新型コロナウィルス最新状況は、陽性件数が1件・PCR検査が58件・抗原検査が15件・現在の入院患者は5人です。

と、日付が1日遅れて計算されている。
