### PR TITLE
画面上のaタグのリンク切れをチェックする

### DIFF
--- a/.github/workflows/check_broken_links.yml
+++ b/.github/workflows/check_broken_links.yml
@@ -1,0 +1,57 @@
+name: check broken links
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  check_broken_links:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.7.1'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: yarn Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: yarn install
+        run: yarn install --frozen-lockfile
+      - name: Set bundle cache directory path
+        id: bundle-cache-dir-path
+        run: |
+          bundle config path vendor/bundle
+          echo "::set-output name=dir::vendor/bundle"
+      - name: bundle Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.bundle-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-bundle-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bundle-
+      - name: bundle install
+        run: bundle install --jobs 4 --retry 3
+      - name: generate site
+        run: |
+          yarn run generate:deploy --fail-on-page-error
+        env:
+          TZ: Asia/Tokyo
+      - name: run localhost:3000
+        run: |
+          yarn run start &
+      - name: rspec
+        run: |
+          bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ogp/*
 # data_tools
 /data_tools/google_sheets_to_data_json/credentials.json
 /data_tools/google_sheets_to_data_json/token.yaml
+
+# bundle path
+vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+ruby '2.7.1'
+
+gem 'capybara', '>= 2.15'
+gem 'rspec'
+gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,57 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    capybara (3.33.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
+    diff-lcs (1.4.4)
+    mini_mime (1.0.2)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
+    public_suffix (4.0.6)
+    rack (2.2.3)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    regexp_parser (1.7.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    rubyzip (2.3.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  capybara (>= 2.15)
+  rspec
+  selenium-webdriver
+
+RUBY VERSION
+   ruby 2.7.1p83
+
+BUNDLED WITH
+   2.1.4

--- a/spec/feature/check_broken_links_spec.rb
+++ b/spec/feature/check_broken_links_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'json'
+require 'net/http'
+
+# 1. Vue.js を chrome (mobile emulation iPhone 6/7/8) で解釈する
+# 2. ページ上の a href を 全部探す
+# 3. href を GET してみて、 status code が 200 を確認
+# なぜなら、盛岡市の個別事例ページがよく URL が変更になって 404 になるから。
+
+describe "iPhone 6/7/8", type: :feature do
+  context 'page [/]' do
+    urls = []
+
+    # data.json の 陽性事例の 個別ページのURL は直接読み込む
+    data_json = JSON.load(File.open(File.join(__dir__, '../../data/data.json')))
+    data_json['patients']['data'].each do |item|
+      urls << URI(item['url'])
+    end
+
+    before do
+      # chromeで / にアクセスして a タグを全部探す
+      visit '/'
+      page.all('a').each do |a|
+        urls << URI(a['href'])
+      end
+    end
+
+    it 'has no broken links' do
+      # すべての href に対して
+      urls.uniq.each do |url|
+        # redirect をフォローしつつステータスコードを確認
+        res = fetch_url_with_redirect(url)
+        expect(res.code).to eq '200' # ページが存在している
+        p res.code, url.to_s
+        sleep 1
+      end
+    end
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,35 @@
+require 'capybara/rspec'
+require 'capybara/dsl'
+require 'selenium-webdriver'
+
+Capybara.register_driver :emulated_chrome_ios do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless')
+  options.add_argument('--disable-gpu')
+  options.add_emulation(device_name: 'iPhone 6/7/8')
+
+  Capybara::Selenium::Driver.new(app,
+                                 browser: :chrome,
+                                 options: options)
+end
+
+Capybara.default_driver = :emulated_chrome_ios
+Capybara.app_host = 'http://localhost:3000'
+
+# Following Redirection
+def fetch_url_with_redirect(uri, limit = 10)
+  # You should choose a better exception.
+  raise ArgumentError, 'too many HTTP redirects' if limit == 0
+  response = Net::HTTP.get_response(uri)
+
+  case response
+  when Net::HTTPSuccess then
+    response
+  when Net::HTTPRedirection then
+    location = response['location']
+    warn "redirected to #{location}"
+    fetch_url_with_redirect(URI("#{uri.scheme}://#{uri.hostname}:#{uri.port}#{location}"), limit - 1)
+  else
+    response.value
+  end
+end


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #692 


## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 盛岡市が公表している個別事例のURLが頻繁に変更される（どうかしてる）
- 旧URLから新URLにリダイレクトされないので、リンク先が404になる
- リンク切れをチェックしたい
- capybara + chrome + rspec で Vue.js を解釈した後のDOMで、a href のリンク切れをチェックする
- development に push されたら、github workflow で rspec を回す
- リンク切れが発生したら、check broken links の github action が fail するので、 Run failed: check broken links のメールが届く
- github action の ログを見ると、どのリンクが404なのか分かる

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
<img width="1143" alt="Screen Shot 2020-09-13 at 01 49 25" src="https://user-images.githubusercontent.com/242669/93000620-9c894d00-f564-11ea-881f-d853f05b038c.png">
