### PR TITLE
fix: github action setup-ruby '2.7'

### DIFF
--- a/.github/workflows/check_broken_links.yml
+++ b/.github/workflows/check_broken_links.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.7.1'
+          ruby-version: '2.7'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 📝 関連する issue / Related Issues
- #692 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- github action の setup-ruby の仕様が変わったので ruby 2.7 と指定する
