### PR TITLE
Newsの本文が複数行になると、日付部分に回り込んで表示されている

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -132,6 +132,7 @@ export default Vue.extend({
 
           @include lessThan($medium) {
             flex: 0 0 100%;
+            font-weight: bold;
           }
 
           color: $gray-1;

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -118,17 +118,17 @@ export default Vue.extend({
 
     &-item {
       &-anchor {
+        display: flex;
         text-decoration: none;
         margin: 5px;
         @include font-size(14);
 
         @include lessThan($medium) {
-          display: flex;
           flex-wrap: wrap;
         }
 
         &-time {
-          flex: 0 0 90px;
+          flex: 0 0 13rem;
 
           @include lessThan($medium) {
             flex: 0 0 100%;


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #754 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- レイアウトCSS調整
- SPの場合はtimeをboldで表示


## Before
<img width="916" alt="Screen Shot 2020-11-14 at 08 06 50" src="https://user-images.githubusercontent.com/242669/99133863-f985aa00-265e-11eb-96c7-c6cf8a01d2fb.png">


## After
<img width="592" alt="Screen Shot 2020-11-14 at 09 46 09" src="https://user-images.githubusercontent.com/242669/99133873-099d8980-265f-11eb-81a8-1158f3ecc9fd.png">
<img width="592" alt="Screen Shot 2020-11-14 at 09 46 27" src="https://user-images.githubusercontent.com/242669/99133876-0bffe380-265f-11eb-8435-0e7e32884c76.png">
<img width="354" alt="Screen Shot 2020-11-14 at 09 46 57" src="https://user-images.githubusercontent.com/242669/99133881-0efad400-265f-11eb-95a3-eaab2c386556.png">
<img width="354" alt="Screen Shot 2020-11-14 at 09 47 08" src="https://user-images.githubusercontent.com/242669/99133882-115d2e00-265f-11eb-9533-d816fbbda6b9.png">




