### PR TITLE
WhatsNewのレイアウトを変更

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -67,10 +67,12 @@ export default Vue.extend({
       return !/^https?:\/\//.test(path)
     },
     formattedDate(dateString: string) {
-      return convertDateToISO8601Format(dateString)
+      return Date.parse(dateString)
+        ? convertDateToISO8601Format(dateString)
+        : ''
     },
     formattedDateForDisplay(dateString: string) {
-      return this.$d(new Date(dateString), 'date')
+      return Date.parse(dateString) ? this.$d(new Date(dateString), 'date') : ''
     },
   },
 })
@@ -128,7 +130,8 @@ export default Vue.extend({
         }
 
         &-time {
-          flex: 0 0 13rem;
+          flex: 0 0 140px;
+          margin-bottom: 0.8rem;
 
           @include lessThan($medium) {
             flex: 0 0 100%;
@@ -140,11 +143,16 @@ export default Vue.extend({
 
         &-link {
           flex: 0 1 auto;
+          padding-left: 1rem;
+          text-indent: -2rem;
+          margin-bottom: 0.8rem;
 
           @include text-link();
 
           @include lessThan($medium) {
-            padding-left: 8px;
+            padding-left: 3rem;
+            text-indent: -2.2rem;
+            margin-bottom: 1rem;
           }
         }
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #764 

## 📝 関連する issue / Related Issues
- #755 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 同じ日のnewsがある場合は、Google Sheets の date を空にできるように対応。同日の先頭の項目だけ date を入力する
- text は「📞 」のように、絵文字 + 半角スペース でアイコンを入力するようにする
- PCとSPの見た目を調整

## Before
<img width="654" alt="Screen Shot 2020-11-16 at 01 08 10" src="https://user-images.githubusercontent.com/242669/99190544-6ce80280-27aa-11eb-9e25-ce31e312d728.png">
<img width="344" alt="Screen Shot 2020-11-16 at 01 09 47" src="https://user-images.githubusercontent.com/242669/99190551-75d8d400-27aa-11eb-9109-595d8b6ef328.png">


## After
<img width="654" alt="Screen Shot 2020-11-16 at 01 09 10" src="https://user-images.githubusercontent.com/242669/99190553-7b361e80-27aa-11eb-8e0d-6ca48768cf06.png">
<img width="344" alt="Screen Shot 2020-11-16 at 01 09 26" src="https://user-images.githubusercontent.com/242669/99190559-81c49600-27aa-11eb-94ed-2c56c9b5bd9c.png">

