### PR TITLE
peter-evans/create-pull-request を v2 から v3 にアップデート

### DIFF
--- a/.github/workflows/i18n_generator.yml
+++ b/.github/workflows/i18n_generator.yml
@@ -28,7 +28,7 @@ jobs:
           python i18n_generator.py
           cd ..
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update assets/locales/ja.json


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #808 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- peter-evans/create-pull-request@v2 は
  https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
  の deprecated の機能を使っているので actions がエラーになる。
- v3 にアップデートする。


