### PR TITLE
download-artifact Compatibility between v1 and v2

### DIFF
--- a/.github/workflows/on_dispatch_from_googleSheetsMenu_master.yml
+++ b/.github/workflows/on_dispatch_from_googleSheetsMenu_master.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: ogp
+          path: ogp
       - name: Commit files
         run: |
           cp -rp ogp static/


### PR DESCRIPTION
When using download-artifact@v1, a directory denoted by the name of the artifact would be created if the path input was not provided. All of the contents would be downloaded to this directory.

With v2, there is no longer an extra directory that is created if the path input is not provided. All the contents are downloaded to the current working directory.

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #768 
