### PR TITLE
余計な build の削除

### DIFF
--- a/.github/workflows/on_dispatch_from_googleSheetsMenu_master.yml
+++ b/.github/workflows/on_dispatch_from_googleSheetsMenu_master.yml
@@ -92,48 +92,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: master
-  build_master:
+  build_and_deploy_production:
     runs-on: ubuntu-18.04
-    needs: commit_ogp_master
-    steps:
-      - name: Setup Timezone
-        run: |
-          sudo timedatectl set-timezone Asia/Tokyo
-      - uses: actions/checkout@v2
-        with:
-          ref: master
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '10.x'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - run: yarn install --frozen-lockfile
-      - run: yarn run test
-      - name: build master
-        run: |
-          echo "GOOGLE_ANALYTICS_ID=${GOOGLE_ANALYTICS_ID}" >> .env.production
-          cat .env.production
-          yarn run generate:deploy --fail-on-page-error
-        env:
-          GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
-          TZ: Asia/Tokyo
-      - name: archive dist
-        uses: actions/upload-artifact@v2
-        with:
-          name: dist
-          path: dist
-  deploy_production:
-    runs-on: ubuntu-18.04
-    needs: build_master
+    needs: generate_ogp_master
     steps:
       - name: Setup Timezone
         run: |


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #768 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- master の deploy における余計な build の削除

## さらに改良するとしたら
```
  generate_ogp_master:
    runs-on: macos-latest
```

の中で
- production のビルド
- OGPの生成
- 生成したOGPのコミット
- 生成された ./dist の production への action-gh-pages@v2

をやれば、もっと短縮できるけど、ubuntu-18.04 じゃなくて macos-latest 環境で生成されたものを production にしてもいいか？
