### PR TITLE
perf: 本番環境で読み込むファイルから `axe-core` を分離する

### DIFF
--- a/plugins/axe.ts
+++ b/plugins/axe.ts
@@ -1,12 +1,11 @@
 import Vue from 'vue'
+const VueAxe = () => import('vue-axe')
+const AXE_LOCALE_JA = () => import('axe-core/locales/ja.json')
 
 const NODE_ENV = process.env.NODE_ENV
 const VUE_AXE = process.env.VUE_AXE
 
 if (NODE_ENV === 'development' && VUE_AXE === 'true') {
-  const VueAxe = require('vue-axe')
-  const AXE_LOCALE_JA = require('axe-core/locales/ja.json')
-
   Vue.use(VueAxe, {
     config: {
       locale: AXE_LOCALE_JA,


### PR DESCRIPTION
https://github.com/tokyo-metropolitan-gov/covid19/pull/5718/files

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #896 

## 📝 関連する issue / Related Issues
- https://github.com/tokyo-metropolitan-gov/covid19/issues/5717
- https://github.com/tokyo-metropolitan-gov/covid19/pull/5718
