### PR TITLE
workflow の ubuntu-latest が 18.04 から 20.04 に変更になるので 18.04 に固定

### DIFF
--- a/.github/workflows/on_pr_to_any_prlabeler.yml
+++ b/.github/workflows/on_pr_to_any_prlabeler.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Label for Transifex
         if: github.actor == 'transifex-integration[bot]' && !endsWith(github.event.pull_request.title, '[manual sync]')

--- a/.github/workflows/on_pr_to_dev_reviewdog.yml
+++ b/.github/workflows/on_pr_to_dev_reviewdog.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   eslint:
     name: check_eslint_error
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/on_pr_to_stage_audit-staging.yml
+++ b/.github/workflows/on_pr_to_stage_audit-staging.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lighthouse:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1

--- a/.github/workflows/on_push_to_dev_i18n_generator.yml
+++ b/.github/workflows/on_push_to_dev_i18n_generator.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   i18n-builder:
     if: false == contains(github.event.commits[0].message, 'Update assets/locales/ja.json')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout development branch
         uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #911 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- ubuntu-latest を ubuntu-18.04 に変更
