### PR TITLE
nuxt.config.ts から mode を削除

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,7 +7,6 @@ const autoprefixer = require('autoprefixer')
 const environment = process.env.NODE_ENV || 'development'
 
 const config: NuxtConfig = {
-  mode: 'universal',
   target: 'static',
   /*
    ** Headers of the page


### PR DESCRIPTION
  // Since nuxt@2.14.5, there have been significant changes.
  // We dealt with typical two (2) out of them:
  // 1) The "mode:" directive got deprecated (seen right below);
  // 2) Autoprefixer has been included so that we can lessen upgrade burden.
  // mode: 'universal',

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #937 
