### PR TITLE
nuxt-purgecss導入で<style module>がpurgeされるのを修正

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -73,7 +73,7 @@ const config: NuxtConfig = {
     '@nuxtjs/vuetify',
     '@nuxt/typescript-build',
     '@nuxtjs/google-analytics',
-    // 'nuxt-purgecss',
+    'nuxt-purgecss',
   ],
   /*
    ** Nuxt.js modules

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -139,6 +139,7 @@ const config: NuxtConfig = {
     },
   },
   purgeCSS: {
+    enabled: true,
     paths: [
       './node_modules/vuetify/dist/vuetify.js',
       './node_modules/vue-spinner/src/ScaleLoader.vue',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -146,6 +146,36 @@ const config: NuxtConfig = {
     ],
     whitelist: ['DataCard', 'GraphLegend'],
     whitelistPatterns: [/(col|row)/],
+
+    // This is nuxt-purgecss 1.0.0 default settings
+    // https://github.com/Developmint/nuxt-purgecss#defaults
+    // This extractor purge <style module>
+    // <style scoped> is not purged by default whitelistPatterns
+    //
+    // extractors: [
+    //   {
+    //     extractor: (content: string) => {
+    //       const contentWithoutStyleBlocks = content.replace(
+    //         /<style[^]+?<\/style>/gi,
+    //         ''
+    //       ) // Remove inline vue styles
+    //       return contentWithoutStyleBlocks.match(/[\w-.:/]+(?<!:)/g) || []
+    //     },
+    //     extensions: ['html', 'vue', 'js'],
+    //   },
+    // ],
+    //
+
+    // so override extractors
+    // https://github.com/Developmint/nuxt-purgecss#use-custom-extractors
+    extractors: () => [
+      {
+        extractor(content: string): RegExpMatchArray | null {
+          return content.match(/[A-z0-9-:\\/]+/g)
+        },
+        extensions: ['html', 'vue', 'js'],
+      },
+    ],
   },
   manifest: {
     name: '岩手県 新型コロナウイルス感染症対策サイト 非公式',


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #957

## 📝 関連する issue / Related Issues
- #950
- #953 
- https://github.com/tokyo-metropolitan-gov/covid19/issues/5685
- https://github.com/tokyo-metropolitan-gov/covid19/pull/5701

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- nuxt-purgecss の デフォルトの extractors を override して解決したはず


## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

purgecssなし
<img width="1062" alt="Screen Shot 2020-12-06 at 12 27 51" src="https://user-images.githubusercontent.com/242669/101270897-09595f80-37c1-11eb-8367-29cfa7436c86.png">

purgecssあり
<img width="1062" alt="Screen Shot 2020-12-06 at 12 29 19" src="https://user-images.githubusercontent.com/242669/101270893-ffcff780-37c0-11eb-91ae-73a8e19c90ca.png">

再び purgecss を効かせても、<style module> が消されずに残るようになった