### PR TITLE
接触歴不明者数で「増加比」ではなく「前週比」という言葉を使う

### DIFF
--- a/components/cards/UntrackedRateCard.vue
+++ b/components/cards/UntrackedRateCard.vue
@@ -3,7 +3,7 @@
     <client-only>
       <untracked-rate-mixed-chart
         :title-id="'untracked-rate'"
-        :info-titles="[$t('接触歴等不明者数(7日間移動平均)'), $t('増加比')]"
+        :info-titles="[$t('接触歴等不明者数(7日間移動平均)'), $t('前週比')]"
         :chart-id="'untracked-rate-chart'"
         :chart-data="graphData"
         :get-formatter="getFormatter"
@@ -40,7 +40,7 @@
             <li>
               {{
                 $t(
-                  '増加比は１週間前の接触歴等不明者数（移動平均値）との比較、サンプル数が少ないので断続的'
+                  '前週比は１週間前の接触歴等不明者数（移動平均値）との比較、サンプル数が少ないので断続的'
                 )
               }}
             </li>
@@ -86,17 +86,17 @@ export default {
       this.$t('接触歴等判明者数'),
       this.$t('接触歴等不明者数'),
       this.$t('接触歴等不明者数（７日間移動平均）'),
-      this.$t('増加比'),
+      this.$t('前週比'),
     ]
     const tableLabels = [
       this.$t('接触歴等判明者数'),
       this.$t('接触歴等不明者数'),
       this.$t('接触歴等不明者数（７日間移動平均）'),
-      this.$t('増加比'),
+      this.$t('前週比'),
     ]
 
     const getFormatter = (columnIndex) => {
-      // 7日間移動平均と増加比は小数点第1位まで表示する。
+      // 7日間移動平均と前週比は小数点第1位まで表示する。
       if (columnIndex >= 2) {
         return getNumberToFixedFunction(1)
       }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #865 

## 関連する
- https://github.com/tokyo-metropolitan-gov/covid19/issues/5595

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「増加比」ではなく「前週比」という言葉を使う
- サンプル数が少なく機能しないので、引き続き目立たない表示

