### PR TITLE
github actions を ubuntu-18.04 から ubuntu-20.04 に変更

### DIFF
--- a/.github/workflows/on_dispatch_from_googleSheetsMenuWithoutOGP_master.yml
+++ b/.github/workflows/on_dispatch_from_googleSheetsMenuWithoutOGP_master.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update_json_master:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -33,7 +33,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: master
   deploy_production:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: update_json_master
     steps:
       - name: Setup Timezone

--- a/.github/workflows/on_dispatch_from_googleSheetsMenu_development.yml
+++ b/.github/workflows/on_dispatch_from_googleSheetsMenu_development.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update_json_development:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -33,7 +33,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: development
   check_broken_links:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: update_json_development
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/on_pr_to_any_prlabeler.yml
+++ b/.github/workflows/on_pr_to_any_prlabeler.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   triage:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Label for Transifex
         if: github.actor == 'transifex-integration[bot]' && !endsWith(github.event.pull_request.title, '[manual sync]')

--- a/.github/workflows/on_pr_to_dev_reviewdog.yml
+++ b/.github/workflows/on_pr_to_dev_reviewdog.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   eslint:
     name: check_eslint_error
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -36,7 +36,7 @@ jobs:
 
   stylelint:
     name: check_stylelint_error
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: stylelint review

--- a/.github/workflows/on_pr_to_stage_audit-staging.yml
+++ b/.github/workflows/on_pr_to_stage_audit-staging.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lighthouse:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1

--- a/.github/workflows/on_push_to_dev_i18n_generator.yml
+++ b/.github/workflows/on_push_to_dev_i18n_generator.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   i18n-builder:
     if: false == contains(github.event.commits[0].message, 'Update assets/locales/ja.json')
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout development branch
         uses: actions/checkout@v2

--- a/.github/workflows/on_push_to_stage_staging.yml
+++ b/.github/workflows/on_push_to_stage_staging.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 📝 関連する issue / Related Issues
- #768 

## ⛏ 変更内容 / Details of Changes
- github actions の環境を ubuntu-20.04 に変更
- ```https://www.mext.go.jp/content/20201203-mxt_kouhou01-000004520_01.pdf```のURLを```check_broken_links```する時に、www.mext.go.jp が 自ドメインのcertは送ってくるが、中間証明書のCybertrust Japan Public CA G3をbundleして送ってこないので、net/http とか wget でcertのverifyで失敗する。
- ubuntu-20.04ならCybertrust Japan Public CA G3が入っているのではないか期待。
- これで治らなかったら github actions 環境に Cybertrust Japan Public CA G3 の中間証明書をインストールする必要がある。
