### PR TITLE
死亡を退院等の子要素としない

### DIFF
--- a/components/ConfirmedCasesDetailsTable.vue
+++ b/components/ConfirmedCasesDetailsTable.vue
@@ -56,7 +56,7 @@
             </span>
           </div>
         </li>
-        <li :class="[$style.box, $style.parent]">
+        <li :class="$style.box">
           <div :class="$style.content">
             <span>{{ $t('退院等') }}</span>
             <span>
@@ -64,17 +64,15 @@
               <span :class="$style.unit">{{ $t('人') }}</span>
             </span>
           </div>
-          <ul :class="[$style.group]">
-            <li :class="[$style.box]">
-              <div :class="$style.content">
-                <span>{{ $t('死亡') }}</span>
-                <span>
-                  <strong>{{ 死亡.toLocaleString() }}</strong>
-                  <span :class="$style.unit">{{ $t('人') }}</span>
-                </span>
-              </div>
-            </li>
-          </ul>
+        </li>
+        <li :class="$style.box">
+          <div :class="$style.content">
+            <span>{{ $t('死亡') }}</span>
+            <span>
+              <strong>{{ 死亡.toLocaleString() }}</strong>
+              <span :class="$style.unit">{{ $t('人') }}</span>
+            </span>
+          </div>
         </li>
       </ul>
     </li>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #856 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 12月10日から死亡を退院等に含めずに発表するようになったため、レイアウト変更

## 📸 スクリーンショット / Screenshots

### Before
<img src="https://user-images.githubusercontent.com/242669/102315123-f449b100-3fb6-11eb-93da-62ad2a2c2a97.png" width="50%">

### After
<img src="https://user-images.githubusercontent.com/242669/102315101-e5fb9500-3fb6-11eb-8fbd-ba05b98baa54.png" width="50%">
