### PR TITLE
defaultAssetsをfalseにして自動的にrobotoのlink relが生成されるのを防ぐ

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -1,5 +1,6 @@
 // ==================
 // font
+$font-size-root: 10px;
 $body-font-family: "Roboto", "Helvetica Neue", "Arial", "ヒラギノ角ゴ ProN", "Hiragino Kaku Gothic ProN", "Hiragino Sans", "YuGothic", "Yu Gothic", "Meiryo", sans-serif;
 
 // ==================

--- a/nuxt.config.dev.ts
+++ b/nuxt.config.dev.ts
@@ -98,11 +98,7 @@ const config: NuxtConfig = {
     customVariables: ['@/assets/variables.scss'],
     optionsPath: './plugins/vuetify.options.ts',
     treeShake: true,
-    defaultAssets: {
-      font: {
-        size: 10,
-      },
-    },
+    defaultAssets: false,
   },
   googleAnalytics: {
     id: process.env.GOOGLE_ANALYTICS_ID, // .env.production などに設定してください。

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -95,11 +95,7 @@ const config: NuxtConfig = {
     customVariables: ['@/assets/variables.scss'],
     optionsPath: './plugins/vuetify.options.ts',
     treeShake: true,
-    defaultAssets: {
-      font: {
-        size: 10,
-      },
-    },
+    defaultAssets: false,
   },
   googleAnalytics: {
     id: process.env.GOOGLE_ANALYTICS_ID, // .env.production などに設定してください。


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1090 

## ⛏ 変更内容 / Details of Changes
- defaultAssetsをfalseにしないと、自動的にgoogle fontsを読み込むlink relが出力されて読み込みにいってしまう
- ベースの文字サイズはfont-size-rootで指定する

