### PR TITLE
PCR検査件数と抗原検査件数はpositive_rate.jsonの個別値から計算する

### DIFF
--- a/components/cards/TestedNumberCard.vue
+++ b/components/cards/TestedNumberCard.vue
@@ -6,7 +6,7 @@
         :title-id="'number-of-tested'"
         :chart-id="'time-stacked-bar-chart-inspections'"
         :chart-data="inspectionsGraph"
-        :date="Data.inspections_summary.date"
+        :date="PositiveRate.date"
         :items="inspectionsItems"
         :labels="inspectionsLabels"
         :unit="$t('件.tested')"
@@ -34,7 +34,7 @@
 <script>
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
-import Data from '@/data/data.json'
+import PositiveRate from '@/data/positive_rate.json'
 import { getDayjsObject } from '@/utils/formatDate'
 import TimeStackedBarChart from '@/components/TimeStackedBarChart.vue'
 dayjs.extend(duration)
@@ -45,20 +45,19 @@ export default {
   },
   data() {
     // 検査実施日別状況
-    const { data } = Data.inspections_summary
-    const pcr = Array.from(data['PCR検査'].keys()).map(
-      (i) => data['PCR検査'][i]
-    )
-    const antigen = Array.from(data['抗原検査'].keys()).map(
-      (i) => data['抗原検査'][i]
-    )
+    const pcr = PositiveRate.data.map((d) => {
+      return (d.pcr_positive_count ?? 0) + (d.pcr_negative_count ?? 0)
+    })
+    const antigen = PositiveRate.data.map((d) => {
+      return (d.antigen_positive_count ?? 0) + (d.antigen_negative_count ?? 0)
+    })
     const inspectionsGraph = [pcr, antigen]
     const inspectionsItems = [
       this.$t('PCR検査実施件数'),
       this.$t('抗原検査件数'),
     ]
-    const inspectionsLabels = Data.inspections_summary.labels.map((d) => {
-      return getDayjsObject(d).format('YYYY-MM-DD')
+    const inspectionsLabels = PositiveRate.data.map((d) => {
+      return getDayjsObject(d.diagnosed_date).format('YYYY-MM-DD')
     })
     const inspectionsDataLabels = [
       this.$t('PCR検査実施件数'),
@@ -70,7 +69,7 @@ export default {
     ]
 
     return {
-      Data,
+      PositiveRate,
       inspectionsGraph,
       inspectionsItems,
       inspectionsLabels,

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -34,7 +34,6 @@
 import Vue from 'vue'
 import { MetaInfo, LinkPropertyHref } from 'vue-meta'
 import ScaleLoader from 'vue-spinner/src/ScaleLoader.vue'
-import Data from '@/data/data.json'
 import PositiveRate from '@/data/positive_rate.json'
 import PositiveStatus from '@/data/positive_status.json'
 import SideNavigation from '@/components/SideNavigation.vue'
@@ -97,8 +96,10 @@ export default Vue.extend({
     })}${this.$t('は陽性が')}${
       PositiveRate.data.slice(-1)[0].positive_count
     }${this.$t('件・検査が')}${
-      Data.inspections_summary.data.PCR検査.slice(-1)[0] +
-      Data.inspections_summary.data.抗原検査.slice(-1)[0]
+      (PositiveRate.data.slice(-1)[0].pcr_positive_count ?? 0) +
+      (PositiveRate.data.slice(-1)[0].pcr_negative_count ?? 0) +
+      (PositiveRate.data.slice(-1)[0].antigen_positive_count ?? 0) +
+      (PositiveRate.data.slice(-1)[0].antigen_negative_count ?? 0)
     }${this.$t('件・現在の入院患者は')}${
       PositiveStatus.data.slice(-1)[0].hospitalized
     }${this.$t('人です。')}`

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -19,7 +19,6 @@ import HospitalizedNumberCard from '@/components/cards/HospitalizedNumberCard.vu
 // import PositiveNumberByDevelopedDateCard from '@/components/cards/PositiveNumberByDevelopedDateCard.vue'
 import { getLinksLanguageAlternative } from '@/utils/i18nUtils'
 import { convertDateToJapaneseKanjiFormat } from '@/utils/formatDate.ts'
-import Data from '@/data/data.json'
 import PositiveRate from '@/data/positive_rate.json'
 import PositiveStatus from '@/data/positive_status.json'
 
@@ -106,8 +105,10 @@ export default {
     })}${this.$t('は陽性が')}${
       PositiveRate.data.slice(-1)[0].positive_count
     }${this.$t('件・検査が')}${
-      Data.inspections_summary.data.PCR検査.slice(-1)[0] +
-      Data.inspections_summary.data.抗原検査.slice(-1)[0]
+      (PositiveRate.data.slice(-1)[0].pcr_positive_count ?? 0) +
+      (PositiveRate.data.slice(-1)[0].pcr_negative_count ?? 0) +
+      (PositiveRate.data.slice(-1)[0].antigen_positive_count ?? 0) +
+      (PositiveRate.data.slice(-1)[0].antigen_negative_count ?? 0)
     }${this.$t('件・現在の入院患者は')}${
       PositiveStatus.data.slice(-1)[0].hospitalized
     }${this.$t(


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1100 

## ⛏ 変更内容 / Details of Changes
- 各検査件数は positive_rate.json の個別値から計算する
- data.json の inspections_summary は削除する

