### PR TITLE
CardsTabの方でclient-onlyをする

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,37 +1,6 @@
 <template>
   <div>
-    <LazySiteTopUpper />
-    <LazyCardsTab />
+    <site-top-upper />
+    <lazy-cards-tab />
   </div>
 </template>
-
-<script lang="ts">
-import Vue from 'vue'
-import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
-
-type Data = {
-  showCardsTab: boolean
-}
-type Methods = {
-  onScroll: () => void
-}
-type Computed = {}
-type Props = {}
-
-const options: ThisTypedComponentOptionsWithRecordProps<
-  Vue,
-  Data,
-  Methods,
-  Computed,
-  Props
-> = {
-  name: 'Index',
-  data() {
-    return {
-      showCardsTab: false,
-    }
-  },
-}
-
-export default options
-</script>


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #1143 

## ⛏ 変更内容 / Details of Changes
- 東京版と違いWhatsNewがCardsとしてtabの中にあるので、スクロールしてからlazyで読み込む方法は取らずに、最初からlazyで読み込む。mobileの場合のFirstContentfulPaintで不利になるが、現状ではこの実装。
