### PR TITLE
3.05.toFixed(1)と3.05.round(1)の丸誤差の違い

### DIFF
--- a/spec/feature/index_PositiveRateCard_spec.rb
+++ b/spec/feature/index_PositiveRateCard_spec.rb
@@ -67,11 +67,11 @@ describe "iPhone 6/7/8", type: :feature do
         expect(find('#PositiveRateCard .DataViewExpansionPanel .v-expansion-panel-content table > tbody > tr:nth-child(4) > td:nth-child(5)').text).to eq "#{d}"
 
         # テーブルの上から4行目をチェックする(検査件数 7-MA)
-        d = number_to_delimited(positive_rate_json['data'][-4]['weekly_average_diagnosed_count'].to_f)
+        d = number_to_delimited(page.evaluate_script("#{positive_rate_json['data'][-4]['weekly_average_diagnosed_count']}.toFixed(1)"))
         expect(find('#PositiveRateCard .DataViewExpansionPanel .v-expansion-panel-content table > tbody > tr:nth-child(4) > td:nth-child(6)').text).to eq "#{d}"
 
         # テーブルの上から4行目をチェックする(陽性率)
-        d = number_to_delimited(positive_rate_json['data'][-4]['positive_rate'].round(1))
+        d = number_to_delimited(page.evaluate_script("#{positive_rate_json['data'][-4]['positive_rate']}.toFixed(1)"))
         expect(find('#PositiveRateCard .DataViewExpansionPanel .v-expansion-panel-content table > tbody > tr:nth-child(4) > td:nth-child(7)').text).to eq "#{d}"
 
         # データを表示ボタンをクリックすると閉じる

--- a/spec/feature/index_UntrackedRateCard_spec.rb
+++ b/spec/feature/index_UntrackedRateCard_spec.rb
@@ -22,7 +22,7 @@ describe "iPhone 6/7/8", type: :feature do
         expect(find('#UntrackedRateCard > div > div > div.DataView-Header > div > div > div > small').text).to match "^#{d} の数値"
 
         # 接触歴等不明者数(7日間移動平均)
-        d = number_to_delimited((daily_positive_detail_json['data'].last['weekly_average_untracked_count']).round(1))
+        d = number_to_delimited(page.evaluate_script("#{daily_positive_detail_json['data'].last['weekly_average_untracked_count']}.toFixed(1)"))
         expect(find('#UntrackedRateCard > div > div > div.DataView-Header > div > div > div > span > strong').text).to eq "#{d}"
 
         # 接触歴等不明者数(7日間移動平均)(実際に計算してみる)


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1196 

## ⛏ 変更内容 / Details of Changes
- 丸誤差の違いを吸収するためrspecの中でjsを実行した値を使う
