### PR TITLE
グラフの横幅をスマホは4、タブレットとPCは6に固定

### DIFF
--- a/components/ScrollableChart.vue
+++ b/components/ScrollableChart.vue
@@ -31,7 +31,6 @@ type Computed = {
 }
 type Props = {
   displayData: DisplayData
-  isWeekly: boolean
 }
 
 const options: ThisTypedComponentOptionsWithRecordProps<
@@ -45,11 +44,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     displayData: {
       type: Object as PropType<DisplayData>,
       required: true,
-    },
-    isWeekly: {
-      type: Boolean,
-      required: false,
-      default: false,
     },
   },
   data() {

--- a/components/ScrollableChart.vue
+++ b/components/ScrollableChart.vue
@@ -76,11 +76,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       this.chartWidth = this.calcChartWidth(containerWidth, this.labelCount)
     },
     calcChartWidth(containerWidth, labelCount) {
-      const dates = 60
-      const weeks = 24
       const yaxisWidth = 38
-      const chartWidth = containerWidth - yaxisWidth
-      const barWidth = chartWidth / (this.isWeekly ? weeks : dates)
+      const barWidth = this.$nuxt.$vuetify.breakpoint.smAndDown ? 4 : 6
       const calcWidth = barWidth * labelCount + yaxisWidth
       return Math.max(calcWidth, containerWidth)
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
     "types": [
       "@types/node",
       "@nuxt/types",
-      "nuxt-i18n"
+      "nuxt-i18n",
+      "vuetify"
     ]
   },
   "exclude": [


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1305 


## ⛏ 変更内容 / Details of Changes
- グラフの横幅をスマホは4、タブレットとPCは6に固定
- 利用していない is-weekly を削除
