### PR TITLE
remove prettier/vue setting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   plugins: ['eslint-plugin-tsdoc', 'simple-import-sort'],
   extends: [
     '@nuxtjs/eslint-config-typescript',
-    'prettier/vue',
     'prettier',
     'plugin:prettier/recommended',
   ],


### PR DESCRIPTION
```
Error: "prettier/vue" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
```

## 📝 関連する issue / Related Issues
- #1340 
