### PR TITLE
Typescript 4.2.3 でのビルドエラーへの対応(importで.ts拡張子を削除 / dateTimeFormatsCommonに型を追加)

### DIFF
--- a/components/AppLink.vue
+++ b/components/AppLink.vue
@@ -19,7 +19,7 @@
 import { mdiOpenInNew } from '@mdi/js'
 import Vue from 'vue'
 
-import { isExternal } from '@/utils/urls.ts'
+import { isExternal } from '@/utils/urls'
 
 type InternalAttr = {
   to: String

--- a/components/CardsTab.vue
+++ b/components/CardsTab.vue
@@ -24,7 +24,7 @@
 import { mdiChartTimelineVariant } from '@mdi/js'
 import Vue from 'vue'
 
-import { EventBus, TOGGLE_EVENT } from '@/utils/tab-event-bus.ts'
+import { EventBus, TOGGLE_EVENT } from '@/utils/tab-event-bus'
 
 const CardsMonitoring = () => import('@/components/CardsMonitoring.vue')
 const CardsReference = () => import('@/components/CardsReference.vue')

--- a/components/ScrollableChart.vue
+++ b/components/ScrollableChart.vue
@@ -14,7 +14,7 @@ import Vue, { PropType } from 'vue'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 
 import { DisplayData } from '@/plugins/vue-chart'
-import { EventBus, TOGGLE_EVENT } from '@/utils/tab-event-bus.ts'
+import { EventBus, TOGGLE_EVENT } from '@/utils/tab-event-bus'
 
 type Data = {
   chartWidth: number

--- a/nuxt-i18n.config.ts
+++ b/nuxt-i18n.config.ts
@@ -1,6 +1,7 @@
 import type { NuxtVueI18n } from 'nuxt-i18n'
+import { DateTimeFormat } from 'vue-i18n'
 
-const dateTimeFormatsCommon = {
+const dateTimeFormatsCommon: DateTimeFormat = {
   dateTime: {
     year: 'numeric',
     month: 'short',


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #1345 

## ⛏ 変更内容 / Details of Changes
- typescript 4.2.3 でのビルドエラーへの対応を追加
- import の .ts 拡張子を削除
- dateTimeFormatsCommon に 型を追加

