### PR TITLE
Service Workerを登録解除するスクリプトを追加

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -291,6 +291,15 @@ export default Vue.extend({
       ],
     }
   },
+  created() {
+    if (process.client) {
+      navigator.serviceWorker.getRegistrations().then(function (registrations) {
+        for (const registration of registrations) {
+          registration.unregister()
+        }
+      })
+    }
+  },
   mounted() {
     this.loading = false
     this.getMatchMedia().addListener(this.closeNavigation)


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1401 

## 📝 関連する issue / Related Issues
- #1112 

## ⛏ 変更内容 / Details of Changes
- Service Workerが登録済の環境の人のブラウザから、Service Workerを登録解除する

このコードによって、sw.js が Service Worker から登録解除される


### Before
<img width="727" alt="Screen Shot 2021-03-17 at 2 07 21 PM" src="https://user-images.githubusercontent.com/242669/111418018-3efbd600-872a-11eb-805d-9ace1269ab0b.png">

### After
<img width="727" alt="Screen Shot 2021-03-17 at 2 07 31 PM" src="https://user-images.githubusercontent.com/242669/111418028-44592080-872a-11eb-8d4c-3d19cffc41d0.png">
<img width="727" alt="Screen Shot 2021-03-17 at 2 07 41 PM" src="https://user-images.githubusercontent.com/242669/111418043-4b802e80-872a-11eb-888f-445f7309edc2.png">


