### PR TITLE
ServiceWorkerの登録解除する方法を東京版に合わせる

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -291,15 +291,6 @@ export default Vue.extend({
       ],
     }
   },
-  created() {
-    if (process.client) {
-      navigator.serviceWorker.getRegistrations().then(function (registrations) {
-        for (const registration of registrations) {
-          registration.unregister()
-        }
-      })
-    }
-  },
   mounted() {
     this.loading = false
     this.getMatchMedia().addListener(this.closeNavigation)

--- a/nuxt.config.dev.ts
+++ b/nuxt.config.dev.ts
@@ -189,7 +189,9 @@ const config: NuxtConfig = {
       name: '岩手県 新型コロナウイルス感染症対策サイト 非公式',
       short_name: '岩手COVID19',
     },
-    workbox: false,
+    workbox: {
+      enabled: false,
+    },
   },
   generate: {
     fallback: true,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -182,7 +182,9 @@ const config: NuxtConfig = {
       short_name: '岩手COVID19',
       lang: 'ja',
     },
-    workbox: false,
+    workbox: {
+      enabled: false,
+    },
   },
   generate: {
     fallback: true,

--- a/spec/feature/check_unregister_serviceworker_spec.rb
+++ b/spec/feature/check_unregister_serviceworker_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+# sw.js で ServiceWorkerのunregisterをする
+
+describe 'iPhone 6/7/8', type: :feature do
+  context 'page [/]' do
+    before do
+      visit '/sw.js'
+    end
+
+    it 'has unregister code' do
+      expect(page.html).to have_content('self.registration.unregister()')
+    end
+  end
+end


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #1401 
- https://github.com/tokyo-metropolitan-gov/covid19/pull/6155

## ⛏ 変更内容 / Details of Changes
- 独自実装から nuxt-pwa を使った実装に変更する

