### PR TITLE
Fix munitipalities customsort

### DIFF
--- a/components/ConfirmedCasesByMunicipalitiesTable.vue
+++ b/components/ConfirmedCasesByMunicipalitiesTable.vue
@@ -79,12 +79,43 @@ export default Vue.extend({
     customSort(items: Object[], index: string[], isDesc: boolean[]) {
       items.sort((a: any, b: any) => {
         let comparison: number
-        if (index[0] === 'label') {
-          // 「市町村(label)」(漢字)でソートすると、実は「ふりがな(ruby)」(ひらがな)でソートされる
-          comparison = a.ruby < b.ruby ? -1 : 1
-        } else {
-          // 市町村(label)以外は、それ自身でソート
-          comparison = a[index[0]] < b[index[0]] ? -1 : 1
+
+        // 「県外」は常に一番下にする
+        if (a.label === '県外') {
+          return Number.MAX_VALUE
+        }
+
+        switch (index[0]) {
+          case 'label':
+            // 「市町村(label)」(漢字)でソートすると、実は「ふりがな(ruby)」(ひらがな)でソートされる
+            comparison = a.ruby < b.ruby ? -1 : 1
+            break
+          case 'count':
+            // 「陽性者数」はIntとしてソートする
+            comparison = parseInt(a.count) < parseInt(b.count) ? -1 : 1
+            break
+          case 'count_per_population':
+            // 「対人口」は%を取り除いてFloatとしてソートする
+            comparison =
+              parseFloat(a.count_per_population) <
+              parseFloat(b.count_per_population)
+                ? -1
+                : 1
+            break
+          case 'last7days':
+            // 「直近1週間」はIntとしてソートする
+            comparison = parseInt(a.last7days) < parseInt(b.last7days) ? -1 : 1
+            break
+          case 'last7_per_100k':
+            // 「直近1週間対人口10万人」はFloatとしてソートする
+            comparison =
+              parseFloat(a.last7_per_100k) < parseFloat(b.last7_per_100k)
+                ? -1
+                : 1
+            break
+          default:
+            comparison = a[index[0]] < b[index[0]] ? -1 : 1
+            break
         }
         return isDesc[0] ? comparison * -1 : comparison
       })

--- a/spec/lib/ConfirmedCasesByMunicipalitiesCard.rb
+++ b/spec/lib/ConfirmedCasesByMunicipalitiesCard.rb
@@ -47,9 +47,97 @@ def has_confirmed_cases_by_municipalities_card
 
   # ふりがなをクリックしてソートしたら、一番上は「いちのせきし」
   find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(2)').click
-  expect(page).to have_selector '#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th.text-start.sortable.active.asc'
+  expect(page).to have_selector '#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(2).text-start.sortable.active.asc'
   expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(1) > td:nth-child(1)').text).to eq '一関市'
   expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(1) > td:nth-child(2)').text).to eq 'いちのせきし'
+
+  # 市町村を2回クリックしても、一番下は常に「県外」
+  find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(1)').click
+  expect(page).to have_selector '#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(1).text-start.sortable.active.asc'
+  expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(34) > td:nth-child(1)').text).to eq '県外'
+  find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(1)').click
+  expect(page).to have_selector '#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(1).text-start.sortable.active.desc'
+  expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(34) > td:nth-child(1)').text).to eq '県外'
+
+  # 陽性者数を1回目クリックしたら昇順に並んでいる。県外は常に一番下
+  find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(3)').click
+  expect(page).to have_selector '#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(3).text-end.sortable.active.asc'
+  expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(34) > td:nth-child(1)').text).to eq '県外'
+  32.times do |i|
+    a = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 1}) > td:nth-child(3)").text
+    b = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 2}) > td:nth-child(3)").text
+    expect(a.to_i <= b.to_i).to be true
+  end
+
+  # 陽性者数を2回目クリックしたら降順に並んでいる。県外は常に一番下
+  find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(3)').click
+  expect(page).to have_selector '#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(3).text-end.sortable.active.desc'
+  expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(34) > td:nth-child(1)').text).to eq '県外'
+  32.times do |i|
+    a = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 1}) > td:nth-child(3)").text
+    b = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 2}) > td:nth-child(3)").text
+    expect(a.to_i >= b.to_i).to be true
+  end
+
+  # 対人口を1回目クリックしたら昇順に並んでいる。県外は常に一番下
+  find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(4)').click
+  expect(page).to have_selector '#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(4).text-end.sortable.active.asc'
+  expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(34) > td:nth-child(1)').text).to eq '県外'
+  32.times do |i|
+    a = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 1}) > td:nth-child(4)").text.gsub('%', '')
+    b = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 2}) > td:nth-child(4)").text.gsub('%', '')
+    expect(a.to_f <= b.to_f).to be true
+  end
+
+  # 対人口を2回目クリックしたら降順に並んでいる。県外は常に一番下
+  find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(4)').click
+  expect(page).to have_selector '#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(4).text-end.sortable.active.desc'
+  expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(34) > td:nth-child(1)').text).to eq '県外'
+  32.times do |i|
+    a = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 1}) > td:nth-child(4)").text.gsub('%', '')
+    b = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 2}) > td:nth-child(4)").text.gsub('%', '')
+    expect(a.to_f >= b.to_f).to be true
+  end
+
+  # 直近1週間を1回目クリックしたら昇順に並んでいる。県外は常に一番下
+  find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(5)').click
+  expect(page).to have_selector '#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(5).text-end.sortable.active.asc'
+  expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(34) > td:nth-child(1)').text).to eq '県外'
+  32.times do |i|
+    a = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 1}) > td:nth-child(5)").text
+    b = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 2}) > td:nth-child(5)").text
+    expect(a.to_i <= b.to_i).to be true
+  end
+
+  # 直近1週間を2回目クリックしたら降順に並んでいる。県外は常に一番下
+  find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(5)').click
+  expect(page).to have_selector '#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(5).text-end.sortable.active.desc'
+  expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(34) > td:nth-child(1)').text).to eq '県外'
+  32.times do |i|
+    a = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 1}) > td:nth-child(5)").text
+    b = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 2}) > td:nth-child(5)").text
+    expect(a.to_i >= b.to_i).to be true
+  end
+
+  # 直近1週間を1回目クリックしたら昇順に並んでいる。県外は常に一番下
+  find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(6)').click
+  expect(page).to have_selector '#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(6).text-end.sortable.active.asc'
+  expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(34) > td:nth-child(1)').text).to eq '県外'
+  32.times do |i|
+    a = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 1}) > td:nth-child(6)").text
+    b = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 2}) > td:nth-child(6)").text
+    expect(a.to_f <= b.to_f).to be true
+  end
+
+  # 直近1週間を1回目クリックしたら昇順に並んでいる。県外は常に一番下
+  find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(6)').click
+  expect(page).to have_selector '#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(6).text-end.sortable.active.desc'
+  expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(34) > td:nth-child(1)').text).to eq '県外'
+  32.times do |i|
+    a = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 1}) > td:nth-child(6)").text
+    b = find("#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(#{i + 2}) > td:nth-child(6)").text
+    expect(a.to_f >= b.to_f).to be true
+  end
 
   # 注釈を表示ボタンの文言
   expect(find('#ConfirmedCasesByMunicipalitiesCard .NotesExpansionPanel button.v-expansion-panel-header').text).to eq '注釈'


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1467 

## ⛏ 変更内容 / Details of Changes
- 市町村別テーブルの数値でソートして欲しい部分を正しく数値でソート
- 県外は常に一番下にする
- 降順・昇順のテスト
