### PR TITLE
fix: layout no-wrap

### DIFF
--- a/components/ConfirmedCasesDetailsTable.vue
+++ b/components/ConfirmedCasesDetailsTable.vue
@@ -281,7 +281,9 @@ $default-boxdiff: 35px;
 
   span.dailyDiff {
     display: inline-block;
-    width: 3em;
+    text-align: center;
+    white-space: nowrap;
+    min-width: 4rem;
     @include font-size(11);
   }
 }


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #1479 

## ⛏ 変更内容 / Details of Changes
- iPhone で [ +10 ] が改行していたので no-wrap
