### PR TITLE
市町村ごとの感染状況を地図の塗り分けで表現: マウスオーバー時のスタイルを変更

### DIFF
--- a/components/WeeklyMap.vue
+++ b/components/WeeklyMap.vue
@@ -162,10 +162,18 @@ export default Vue.extend({
           .append('path')
           .attr('d', path as any)
           .on('mouseenter', function () {
-            d3.select(this).attr('opacity', 0.7)
+            d3.select(this)
+              .attr('stroke', '#666')
+              .attr('stroke-width', '3px')
+              .each(function () {
+                const gElement = this.parentNode as Node & globalThis.ParentNode
+                const svgElement = gElement.parentNode as Node &
+                  globalThis.ParentNode
+                svgElement.appendChild(gElement)
+              })
           })
           .on('mouseout', function () {
-            d3.select(this).attr('opacity', 1)
+            d3.select(this).attr('stroke', '#aaa').attr('stroke-width', '1px')
           })
           .append('svg:title')
           .text((d: any) => {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #1559

## 📝 関連する issue / Related Issues
- #1560, #1563, #1566

## ⛏ 変更内容 / Details of Changes
- 地図上でマウスオーバーした際に，市町村の色が変わるのではなく，ボーダーの色と太さが変わるように変更
  - 修正前は，盛岡市にマウスオーバーすると宮古市と同じような色になったり，岩泉町にマウスオーバーすると久慈市と同じような色になったりして違和感があったため

## 📸 スクリーンショット / Screenshots
<img width="545" alt="スクリーンショット 2021-04-26 23 33 17" src="https://user-images.githubusercontent.com/23148331/116100412-d8ce7f80-a6e7-11eb-80fe-15dee099186a.png">
