### PR TITLE
#1569 マウスオーバーで市町村のボーダーの色を999・太さ2pxに調整

### DIFF
--- a/components/WeeklyMap.vue
+++ b/components/WeeklyMap.vue
@@ -163,8 +163,8 @@ export default Vue.extend({
           .attr('d', path as any)
           .on('mouseenter', function () {
             d3.select(this)
-              .attr('stroke', '#666')
-              .attr('stroke-width', '3px')
+              .attr('stroke', '#999')
+              .attr('stroke-width', '2px')
               .each(function () {
                 const gElement = this.parentNode as Node & globalThis.ParentNode
                 const svgElement = gElement.parentNode as Node &


### PR DESCRIPTION
ちょっとデザインの変更をしてみました。

## 👏 解決する issue / Resolved Issues
- #1569 

## 📝 関連する issue / Related Issues
- #1559 

## ⛏ 変更内容 / Details of Changes
- 666の3pxだと目立ちすぎる感じがするので、少し控えめに調整

## 📸 スクリーンショット / Screenshots

<img width="532" alt="Screen Shot 2021-04-27 at 1 12 40 AM" src="https://user-images.githubusercontent.com/242669/116116209-de32c680-a6f5-11eb-96d7-c2c212105796.png">
