### PR TITLE
CapybaraのChrome起動オプションでGoogle Analyticsを明示的に迂回する

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ Capybara.register_driver :emulated_chrome_ios do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument('--headless')
   options.add_argument('--disable-gpu')
+  options.add_argument('--host-resolver-rules=MAP www.google-analytics.com 127.0.0.1, MAP www.googletagmanager.com 127.0.0.1')
   options.add_emulation(device_name: 'iPhone 6/7/8')
 
   Capybara::Selenium::Driver.new(app,


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #1105 

## ⛏ 変更内容 / Details of Changes
- rspecのcapybaraのchromeでGoogleAnalyticsを回避する
