### PR TITLE
og:title をサイト全体で同じ文言に設定する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby '3.0.1'
 
 gem 'activesupport'
 gem 'capybara'
+gem 'nokogiri'
 gem 'parallel_tests'
 gem 'rspec'
 gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   capybara
+  nokogiri
   parallel_tests
   rspec
   selenium-webdriver

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -76,6 +76,7 @@ export default Vue.extend({
   },
   head(): MetaInfo {
     const { htmlAttrs, meta } = this.$nuxtI18nSeo()
+
     const ogLocale =
       meta && meta.length > 0
         ? meta[0]
@@ -86,6 +87,7 @@ export default Vue.extend({
           }
 
     let linksAlternate: LinkPropertyHref[] = []
+
     const basename = this.getRouteBaseName()
     // 404 エラーなどのときは this.getRouteBaseName() が null になるため除外
     if (basename) {
@@ -95,7 +97,9 @@ export default Vue.extend({
         this.$i18n.defaultLocale
       )
     }
+
     const date = Data.patients_summary.data.slice(-1)[0].日付
+
     const descriptionToday = `${this.$t('{date}', {
       date: this.$d(getDayjsObject(date).toDate(), 'date'),
     })}${this.$t('は陽性が')}${
@@ -108,9 +112,14 @@ export default Vue.extend({
     }${this.$t('件・現在の入院患者は')}${
       PositiveStatus.data.slice(-1)[0].hospitalized
     }${this.$t('人です。')}`
+
     const description = `${descriptionToday}${this.$t(
       '陽性者の属性、検査の陽性率、病床数、市町村別陽性者数、相談件数などの各種データや過去の推移グラフはこちら。'
     )}`
+
+    const defaultTitle = `${this.$t('Common.岩手県')} ${this.$t(
+      'Common.新型コロナウイルス感染症'
+    )}${this.$t('Common.対策サイト')}`
 
     return {
       htmlAttrs,
@@ -244,9 +253,7 @@ export default Vue.extend({
         {
           hid: 'og:site_name',
           property: 'og:site_name',
-          content: `${this.$t('Common.岩手県')} ${this.$t(
-            'Common.新型コロナウイルス感染症'
-          )} ${this.$t('Common.対策サイト')}`,
+          content: defaultTitle,
         },
         {
           hid: 'og:url',
@@ -257,9 +264,7 @@ export default Vue.extend({
         {
           hid: 'og:title',
           property: 'og:title',
-          content: `${this.$t('Common.岩手県')} ${this.$t(
-            'Common.新型コロナウイルス感染症'
-          )}${this.$t('Common.対策サイト')}`,
+          content: defaultTitle,
         },
         {
           hid: 'og:description',
@@ -274,9 +279,7 @@ export default Vue.extend({
         {
           hid: 'apple-mobile-web-app-title',
           name: 'apple-mobile-web-app-title',
-          content: `${this.$t('Common.岩手県')} ${this.$t(
-            'Common.新型コロナウイルス感染症'
-          )} ${this.$t('Common.対策サイト')}`,
+          content: defaultTitle,
         },
         {
           hid: 'twitter:image',

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -259,7 +259,7 @@ export default Vue.extend({
           property: 'og:title',
           content: `${this.$t('Common.岩手県')} ${this.$t(
             'Common.新型コロナウイルス感染症'
-          )} ${this.$t('Common.対策サイト')}`,
+          )}${this.$t('Common.対策サイト')}`,
         },
         {
           hid: 'og:description',

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -184,7 +184,7 @@ export default {
         {
           hid: 'og:title',
           property: 'og:title',
-          template: (title) => `${this.title || title} | ${defaultTitle}`,
+          template: (title) => defaultTitle,
           content: '',
         },
         {

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -142,12 +142,16 @@ export default {
   },
   head() {
     const url = 'https://iwate.stopcovid19.jp'
+
     const timestamp = new Date().getTime()
+
     const ogpImage =
       this.$i18n.locale === 'ja'
         ? `${url}/ogp/${this.$route.params.card}.png?t=${timestamp}`
         : `${url}/ogp/${this.$i18n.locale}/${this.$route.params.card}.png?t=${timestamp}`
+
     const date = Data.patients_summary.data.slice(-1)[0].日付
+
     const description = `${this.$t('{date}', {
       date: this.$d(getDayjsObject(date).toDate(), 'date'),
     })}${this.$t('は陽性が')}${
@@ -162,6 +166,7 @@ export default {
     }${this.$t(
       '人です。陽性者の属性、検査の陽性率、病床数、市町村別陽性者数、相談件数などの各種データや過去の推移グラフはこちら。'
     )}`
+
     const defaultTitle = `${this.$t('Common.岩手県')} ${this.$t(
       'Common.新型コロナウイルス感染症'
     )}${this.$t('Common.対策サイト')}`
@@ -184,7 +189,7 @@ export default {
         {
           hid: 'og:title',
           property: 'og:title',
-          template: (title) => defaultTitle,
+          template: () => defaultTitle,
           content: '',
         },
         {

--- a/spec/feature/cards/cards_ConfirmedCasesAttributesCard_spec.rb
+++ b/spec/feature/cards/cards_ConfirmedCasesAttributesCard_spec.rb
@@ -16,6 +16,13 @@ describe 'iPhone 6/7/8', type: :feature do
       it 'title' do
         expect(title).to eq "#{JA_JSON['ConfirmedCasesAttributesCard']['title']} | #{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:title' do
+        # JS解釈したog:title
+        expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        # JS解釈しないog:title
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/attributes-of-confirmed-cases").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+      end
     end
 
     describe '陽性者の属性(ConfirmedCasesAttributesCard)' do

--- a/spec/feature/cards/cards_ConfirmedCasesByMunicipalitiesCard_spec.rb
+++ b/spec/feature/cards/cards_ConfirmedCasesByMunicipalitiesCard_spec.rb
@@ -17,6 +17,13 @@ describe 'iPhone 6/7/8', type: :feature do
         it 'title' do
           expect(title).to eq "#{LOCALES[lang][:json]['ConfirmedCasesByMunicipalitiesCard']['title']} | #{LOCALES[lang][:json]['Common']['岩手県']} #{LOCALES[lang][:json]['Common']['新型コロナウイルス感染症']}#{LOCALES[lang][:json]['Common']['対策サイト']}"
         end
+
+        it 'og:title' do
+          # JS解釈したog:title
+          expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{LOCALES[lang][:json]['Common']['岩手県']} #{LOCALES[lang][:json]['Common']['新型コロナウイルス感染症']}#{LOCALES[lang][:json]['Common']['対策サイト']}"
+          # JS解釈しないog:title
+          expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/number-of-confirmed-cases-by-municipalities").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        end
       end
 
       describe '陽性患者数(市町村別)(ConfirmedCasesByMunicipalitiesCard)' do

--- a/spec/feature/cards/cards_ConfirmedCasesDetailsCard_spec.rb
+++ b/spec/feature/cards/cards_ConfirmedCasesDetailsCard_spec.rb
@@ -17,6 +17,13 @@ describe 'iPhone 6/7/8', type: :feature do
         it 'title' do
           expect(title).to eq "#{LOCALES[lang][:json]['ConfirmedCasesDetailsCard']['title']} | #{LOCALES[lang][:json]['Common']['岩手県']} #{LOCALES[lang][:json]['Common']['新型コロナウイルス感染症']}#{LOCALES[lang][:json]['Common']['対策サイト']}"
         end
+
+        it 'og:title' do
+          # JS解釈したog:title
+          expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{LOCALES[lang][:json]['Common']['岩手県']} #{LOCALES[lang][:json]['Common']['新型コロナウイルス感染症']}#{LOCALES[lang][:json]['Common']['対策サイト']}"
+          # JS解釈しないog:title
+          expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/details-of-confirmed-cases").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        end
       end
 
       describe '検査陽性者の状況(ConfirmedCasesDetailsCard)' do

--- a/spec/feature/cards/cards_ConfirmedCasesNumberCard_spec.rb
+++ b/spec/feature/cards/cards_ConfirmedCasesNumberCard_spec.rb
@@ -16,6 +16,13 @@ describe 'iPhone 6/7/8', type: :feature do
       it 'title' do
         expect(title).to eq "#{JA_JSON['ConfirmedCasesNumberCard']['title']} | #{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:title' do
+        # JS解釈したog:title
+        expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        # JS解釈しないog:title
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/number-of-confirmed-cases").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+      end
     end
 
     describe '報告日別による陽性者数の推移(ConfirmedCasesNumberCard)' do

--- a/spec/feature/cards/cards_HospitalizedNumberCard_spec.rb
+++ b/spec/feature/cards/cards_HospitalizedNumberCard_spec.rb
@@ -16,6 +16,13 @@ describe 'iPhone 6/7/8', type: :feature do
       it 'title' do
         expect(title).to eq "#{JA_JSON['HospitalizedNumberCard']['title']} | #{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:title' do
+        # JS解釈したog:title
+        expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        # JS解釈しないog:title
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/number-of-hospitalized").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+      end
     end
 
     describe '入院と宿泊療養の推移(HospitalizedNumberCard)' do

--- a/spec/feature/cards/cards_MonitoringConfirmedCasesNumberCard_spec.rb
+++ b/spec/feature/cards/cards_MonitoringConfirmedCasesNumberCard_spec.rb
@@ -16,6 +16,13 @@ describe 'iPhone 6/7/8', type: :feature do
       it 'title' do
         expect(title).to eq "#{JA_JSON['MonitoringConfirmedCasesNumberCard']['titles'].join(',')} | #{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:title' do
+        # JS解釈したog:title
+        expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        # JS解釈しないog:title
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/monitoring-number-of-confirmed-cases").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+      end
     end
 
     describe '新規陽性者数の7日間移動平均(MonitoringConfirmedCasesNumberCard)' do

--- a/spec/feature/cards/cards_MonitoringConsultationDeskReportsNumberCard_spec.rb
+++ b/spec/feature/cards/cards_MonitoringConsultationDeskReportsNumberCard_spec.rb
@@ -16,6 +16,13 @@ describe 'iPhone 6/7/8', type: :feature do
       it 'title' do
         expect(title).to eq "#{JA_JSON['MonitoringConsultationDeskReportsNumberCard']['title']} | #{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:title' do
+        # JS解釈したog:title
+        expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        # JS解釈しないog:title
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/monitoring-number-of-reports-to-covid19-consultation-desk").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+      end
     end
 
     describe '受診・相談センター 受付件数(MonitoringConsultationDeskReportsNumberCard)' do

--- a/spec/feature/cards/cards_PositiveRateCard_spec.rb
+++ b/spec/feature/cards/cards_PositiveRateCard_spec.rb
@@ -16,6 +16,13 @@ describe 'iPhone 6/7/8', type: :feature do
       it 'title' do
         expect(title).to eq "#{JA_JSON['PositiveRateCard']['titles'].join(',')} | #{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:title' do
+        # JS解釈したog:title
+        expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        # JS解釈しないog:title
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/positive-rate").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+      end
     end
 
     describe '検査の陽性率(PositiveRateCard)' do

--- a/spec/feature/cards/cards_SelfDisclosuresCard_spec.rb
+++ b/spec/feature/cards/cards_SelfDisclosuresCard_spec.rb
@@ -16,6 +16,13 @@ describe 'iPhone 6/7/8', type: :feature do
       it 'title' do
         expect(title).to eq "#{JA_JSON['SelfDisclosuresCard']['title']} | #{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:title' do
+        # JS解釈したog:title
+        expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        # JS解釈しないog:title
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/self-disclosures").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+      end
     end
 
     describe '自主公表(SelfDisclosuresCard)' do

--- a/spec/feature/cards/cards_TelephoneAdvisoryReportsNumberCard_spec.rb
+++ b/spec/feature/cards/cards_TelephoneAdvisoryReportsNumberCard_spec.rb
@@ -16,6 +16,13 @@ describe 'iPhone 6/7/8', type: :feature do
       it 'title' do
         expect(title).to eq "#{JA_JSON['TelephoneAdvisoryReportsNumberCard']['title']} | #{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:title' do
+        # JS解釈したog:title
+        expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        # JS解釈しないog:title
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/number-of-reports-to-covid19-telephone-advisory-center").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+      end
     end
 
     describe '一般相談 受付件数(TelephoneAdvisoryReportsNumberCard)' do

--- a/spec/feature/cards/cards_TestedNumberCard_spec.rb
+++ b/spec/feature/cards/cards_TestedNumberCard_spec.rb
@@ -16,6 +16,13 @@ describe 'iPhone 6/7/8', type: :feature do
       it 'title' do
         expect(title).to eq "#{JA_JSON['TestedNumberCard']['title']} | #{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:title' do
+        # JS解釈したog:title
+        expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        # JS解釈しないog:title
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/number-of-tested").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+      end
     end
 
     describe '検査実施件数(TestedNumberCard)' do

--- a/spec/feature/cards/cards_UntrackedRateCard_spec.rb
+++ b/spec/feature/cards/cards_UntrackedRateCard_spec.rb
@@ -16,6 +16,13 @@ describe 'iPhone 6/7/8', type: :feature do
       it 'title' do
         expect(title).to eq "#{JA_JSON['UntrackedRateCard']['titles'].join(',')} | #{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:title' do
+        # JS解釈したog:title
+        expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        # JS解釈しないog:title
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/untracked-rate").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+      end
     end
 
     describe '接触歴等不明者数(7日間移動平均)(UntrackedRateCard)' do

--- a/spec/feature/cards/cards_WhatsNewCard_spec.rb
+++ b/spec/feature/cards/cards_WhatsNewCard_spec.rb
@@ -16,6 +16,13 @@ describe 'iPhone 6/7/8', type: :feature do
       it 'title' do
         expect(title).to eq "#{JA_JSON['WhatsNewCard']['title']} | #{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:title' do
+        # JS解釈したog:title
+        expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+        # JS解釈しないog:title
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/whats-new").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+      end
     end
 
     describe '最新のお知らせ(WhatsNewCard)' do

--- a/spec/feature/index/index_h1h2_spec.rb
+++ b/spec/feature/index/index_h1h2_spec.rb
@@ -13,6 +13,13 @@ describe 'iPhone 6/7/8', type: :feature do
       expect(title).to eq "#{JA_JSON['Common']['岩手の最新感染動向']} | #{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
     end
 
+    it 'og:title' do
+      # JS解釈したog:title
+      expect(find('head meta[property="og:title"]', visible: false)[:content]).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+      # JS解釈しないog:title
+      expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
+    end
+
     it 'h1/h2' do
       expect(find('#app > div > div.appContainer > div > div > header > h1').text).to eq "#{JA_JSON['Common']['新型コロナウイルス感染症']}\n#{JA_JSON['Common']['対策サイト']}"
       expect(find('#app > div > div.appContainer > main > div > div > div.MainPage > div.Header.mb-3 > div.header > h2').text).to eq (JA_JSON['Common']['岩手の最新感染動向']).to_s

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'active_support/all'
 require 'capybara/rspec'
 require 'capybara/dsl'
 require 'json'
+require 'nokogiri'
+require 'open-uri'
 require 'selenium-webdriver'
 
 include ActiveSupport::NumberHelper


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1621 

## ⛏ 変更内容 / Details of Changes
- ` | ` をやめる方向で解決

