### PR TITLE
Whatsnew と SelfDisclosures に ページネーションを追加

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -24,6 +24,10 @@
     "注": "Notes",
     "データを表示": "Show Data Table"
   },
+  "DataView_Footer": [
+    "Items per page",
+    "{pageStart} - {pageStop} of {itemsLength} indexes"
+  ],
   "SiteTopUpper": {
     "最終更新": "Last update",
     "注釈": "This is a provisional translation. Please be aware that there may be mistranslations.",
@@ -463,11 +467,7 @@
       "無": "No",
       "daysbefore": "Zero-day|{d} day before|{d} days before",
       "{age}代": " {age}'s"
-    },
-    "footer": [
-      "Items per page",
-      "{pageStart} - {pageStop} of {itemsLength} indexes"
-    ]
+    }
   },
   "UntrackedRateCard": {
     "titles": [

--- a/assets/locales/ja.json
+++ b/assets/locales/ja.json
@@ -24,6 +24,10 @@
     "注": "注釈",
     "データを表示": "データを表示"
   },
+  "DataView_Footer": [
+    "1ページあたり",
+    "{itemsLength} 項目中 {pageStart} - {pageStop} "
+  ],
   "SiteTopUpper": {
     "最終更新": "最終更新",
     "注釈": "This is a provisional translation. Please be aware that there may be mistranslations.",
@@ -463,11 +467,7 @@
       "無": "無",
       "daysbefore": "{d}日前|{d}日前|{d}日前",
       "{age}代": "{age}代"
-    },
-    "footer": [
-      "1ページあたり",
-      "{itemsLength} 項目中 {pageStart} - {pageStop} "
-    ]
+    }
   },
   "UntrackedRateCard": {
     "titles": [

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -12,7 +12,7 @@
       :custom-sort="customSort"
       :footer-props="{
         'items-per-page-options': [15, 30, 50, 100, 200, 300, -1],
-        'items-per-page-text': $t('ConfirmedCasesAttributesCard.footer[0]'),
+        'items-per-page-text': $t('DataView_Footer[0]'),
       }"
       class="cardTable"
     >
@@ -48,7 +48,7 @@
       </template>
       <template slot="footer.page-text" slot-scope="props">
         {{
-          $t('ConfirmedCasesAttributesCard.footer[1]', {
+          $t('DataView_Footer[1]', {
             itemsLength: props.itemsLength,
             pageStart: props.pageStart,
             pageStop: props.pageStop,

--- a/components/DataViewDataSetPanel.vue
+++ b/components/DataViewDataSetPanel.vue
@@ -24,6 +24,14 @@
       <small v-if="sText !== ''" class="DataView-DataSet-DataInfo-date">
         {{ sText }}
       </small>
+      <div
+        v-if="selfDisclosureForm"
+        class="DataView-DataSet-DataInfo-SelfDisclosureForm"
+      >
+        <app-link to="https://forms.gle/JHB4HJ2c4NnPcmy69">
+          情報提供フォーム
+        </app-link>
+      </div>
     </div>
   </div>
 </template>
@@ -66,6 +74,11 @@ export default Vue.extend({
     cardPath: {
       type: String,
       required: true,
+    },
+    selfDisclosureForm: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
 })
@@ -124,6 +137,15 @@ export default Vue.extend({
         color: $gray-3;
         line-height: initial;
         @include font-size(12);
+      }
+
+      &-SelfDisclosureForm {
+        > a {
+          height: 3rem;
+          line-height: 3rem;
+          display: inline-block;
+          @include font-size(11);
+        }
       }
     }
   }

--- a/components/SelfDisclosures.vue
+++ b/components/SelfDisclosures.vue
@@ -47,9 +47,9 @@
       <data-view-data-set-panel
         :title="title"
         :card-path="`/cards/${titleId}`"
+        :self-disclosure-form="true"
       />
     </template>
-    <slot name="self_disclosure_form" />
   </data-view>
 </template>
 

--- a/components/SelfDisclosures.vue
+++ b/components/SelfDisclosures.vue
@@ -1,6 +1,6 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
-    <div class="WhatsNew-Content">
+    <div class="SelfDisclosures-Content">
       <v-data-table
         :ref="'displayedTable'"
         :items="items"
@@ -49,6 +49,7 @@
         :card-path="`/cards/${titleId}`"
       />
     </template>
+    <slot name="self_disclosure_form" />
   </data-view>
 </template>
 
@@ -123,7 +124,7 @@ export default Vue.extend(options)
 </script>
 
 <style lang="scss">
-.WhatsNew {
+.SelfDisclosures {
   &-Content {
     .cardTable {
       table {

--- a/components/SelfDisclosures.vue
+++ b/components/SelfDisclosures.vue
@@ -4,12 +4,13 @@
       <v-data-table
         :ref="'displayedTable'"
         :items="items"
-        :height="350"
-        :items-per-page="200"
         :mobile-breakpoint="0"
         hide-default-header
-        hide-default-footer
         class="cardTable"
+        :footer-props="{
+          'items-per-page-options': [10, 30, 50, 100, 200, 300, -1],
+          'items-per-page-text': $t('DataView_Footer[0]'),
+        }"
       >
         <template #body="{ items }">
           <tbody>
@@ -30,6 +31,15 @@
               </td>
             </tr>
           </tbody>
+        </template>
+        <template slot="footer.page-text" slot-scope="props">
+          {{
+            $t('DataView_Footer[1]', {
+              itemsLength: props.itemsLength,
+              pageStart: props.pageStart,
+              pageStop: props.pageStop,
+            })
+          }}
         </template>
       </v-data-table>
     </div>

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -4,12 +4,13 @@
       <v-data-table
         :ref="'displayedTable'"
         :items="items"
-        :height="350"
-        :items-per-page="200"
         :mobile-breakpoint="0"
         hide-default-header
-        hide-default-footer
         class="cardTable"
+        :footer-props="{
+          'items-per-page-options': [10, 30, 50, 100, 200, 300, -1],
+          'items-per-page-text': $t('DataView_Footer[0]'),
+        }"
       >
         <template #body="{ items }">
           <tbody>
@@ -30,6 +31,15 @@
               </td>
             </tr>
           </tbody>
+        </template>
+        <template slot="footer.page-text" slot-scope="props">
+          {{
+            $t('DataView_Footer[1]', {
+              itemsLength: props.itemsLength,
+              pageStart: props.pageStart,
+              pageStop: props.pageStop,
+            })
+          }}
         </template>
       </v-data-table>
     </div>

--- a/components/cards/SelfDisclosuresCard.vue
+++ b/components/cards/SelfDisclosuresCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col id="SelfDisclosuresCard" cols="12" :md="md" class="DataCard">
     <client-only>
-      <whats-new
+      <self-disclosures
         :title="$t('SelfDisclosuresCard.title')"
         :title-id="'self-disclosures'"
         :date="date"
@@ -21,7 +21,7 @@
             </app-link>
           </div>
         </template>
-      </whats-new>
+      </self-disclosures>
       <slot name="breadCrumb" />
     </client-only>
   </v-col>
@@ -33,7 +33,7 @@ import Vue from 'vue'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 
 import AppLink from '@/components/AppLink.vue'
-import WhatsNew from '@/components/WhatsNew.vue'
+import SelfDisclosures from '@/components/SelfDisclosures.vue'
 import Data from '@/data/self_disclosures.json'
 
 type NewsItem = {
@@ -60,7 +60,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 > = {
   components: {
     AppLink,
-    WhatsNew,
+    SelfDisclosures,
   },
   props: {
     md: {

--- a/components/cards/SelfDisclosuresCard.vue
+++ b/components/cards/SelfDisclosuresCard.vue
@@ -14,13 +14,6 @@
             </li>
           </ul>
         </template>
-        <template #self_disclosure_form>
-          <div class="self_disclosure_form">
-            <app-link to="https://forms.gle/JHB4HJ2c4NnPcmy69">
-              情報提供フォーム
-            </app-link>
-          </div>
-        </template>
       </self-disclosures>
       <slot name="breadCrumb" />
     </client-only>

--- a/spec/lib/ConfirmedCasesAttributesCard.rb
+++ b/spec/lib/ConfirmedCasesAttributesCard.rb
@@ -75,12 +75,11 @@ def has_confirmed_case_attributes_card
   expect(page.all('#ConfirmedCasesAttributesCard > div > div > div.DataView-Content > div > div.v-data-table__wrapper > table > tbody > tr:nth-child(16)').empty?).to eq true
 
   # １ページあたり
-  expect(find('#ConfirmedCasesAttributesCard > div > div > div.DataView-Content > div > div.v-data-footer > div.v-data-footer__select').text).to eq "#{JA_JSON['ConfirmedCasesAttributesCard']['footer'][0]}\n15"
+  expect(find('#ConfirmedCasesAttributesCard > div > div > div.DataView-Content > div > div.v-data-footer > div.v-data-footer__select').text).to eq "#{JA_JSON['DataView_Footer'][0]}\n15"
 
   # 項目中
-  d = DATA_JSON['patients']['data'].last['id'].to_s
-  expect(find('#ConfirmedCasesAttributesCard > div > div > div.DataView-Content > div > div.v-data-footer > div.v-data-footer__pagination').text).to eq (JA_JSON['ConfirmedCasesAttributesCard']['footer'][1]).to_s.gsub('{itemsLength}', d).gsub('{pageStart}', '1').gsub('{pageStop}',
-                                                                                                                                                                                                                                                                           '15').rstrip
+  d = DATA_JSON['patients']['data'].last['id']
+  expect(find('#ConfirmedCasesAttributesCard > div > div > div.DataView-Content > div > div.v-data-footer > div.v-data-footer__pagination').text).to eq (JA_JSON['DataView_Footer'][1]).to_s.gsub('{itemsLength}', d.to_s).gsub('{pageStart}', '1').gsub('{pageStop}', d < 15 ? d.to_s : '15').rstrip
 
   # 次のページ
   find('#ConfirmedCasesAttributesCard > div > div > div.DataView-Content > div > div.v-data-footer > div.v-data-footer__icons-after > button').click

--- a/spec/lib/SelfDisclosuresCard.rb
+++ b/spec/lib/SelfDisclosuresCard.rb
@@ -22,6 +22,7 @@ def has_self_disclosures_card
     expect(find("#SelfDisclosuresCard > div > div > div.DataView-Content > div > div > div > table > tbody > tr:nth-child(#{1 + index}) > td:nth-child(2)").text).to eq Date.parse(d['date']).strftime('%-m月%-d日').to_s
   end
 
-  expect(find('#SelfDisclosuresCard > div > div > div.DataView-Content > div.self_disclosure_form > a').text).to eq '情報提供フォーム'
-  expect(find('#SelfDisclosuresCard > div > div > div.DataView-Content > div.self_disclosure_form > a')[:href]).to eq 'https://forms.gle/JHB4HJ2c4NnPcmy69'
+  # 情報提供フォームはDataSetPanelの中
+  expect(find('#SelfDisclosuresCard > div > div > div.DataView-Header > div.DataView-DataSetPanel > div.DataView-DataSet > div.DataView-DataSet-DataInfo > div.DataView-DataSet-DataInfo-SelfDisclosureForm > a').text).to eq '情報提供フォーム'
+  expect(find('#SelfDisclosuresCard > div > div > div.DataView-Header > div.DataView-DataSetPanel > div.DataView-DataSet > div.DataView-DataSet-DataInfo > div.DataView-DataSet-DataInfo-SelfDisclosureForm > a')[:href]).to eq 'https://forms.gle/JHB4HJ2c4NnPcmy69'
 end

--- a/spec/lib/SelfDisclosuresCard.rb
+++ b/spec/lib/SelfDisclosuresCard.rb
@@ -10,7 +10,8 @@ def has_self_disclosures_card
 
   # テーブルの中身
   SELF_DISCLOSURES_ITEMS.each_with_index do |d, index|
-    # テーブルの上からi行目をチェックする(icon + text)
+    break if index > 9
+    # テーブルの上から10行目までをチェックする(icon + text)
     if d['url']['ja'].blank?
       expect(page).not_to have_selector("#SelfDisclosuresCard > div > div > div.DataView-Content > div > div > div > table > tbody > tr:nth-child(#{1 + index}) > td:nth-child(1) > a")
       expect(find("#SelfDisclosuresCard > div > div > div.DataView-Content > div > div > div > table > tbody > tr:nth-child(#{1 + index}) > td:nth-child(1)").text).to eq (d['text']['ja']).to_s
@@ -25,4 +26,28 @@ def has_self_disclosures_card
   # 情報提供フォームはDataSetPanelの中
   expect(find('#SelfDisclosuresCard > div > div > div.DataView-Header > div.DataView-DataSetPanel > div.DataView-DataSet > div.DataView-DataSet-DataInfo > div.DataView-DataSet-DataInfo-SelfDisclosureForm > a').text).to eq '情報提供フォーム'
   expect(find('#SelfDisclosuresCard > div > div > div.DataView-Header > div.DataView-DataSetPanel > div.DataView-DataSet > div.DataView-DataSet-DataInfo > div.DataView-DataSet-DataInfo-SelfDisclosureForm > a')[:href]).to eq 'https://forms.gle/JHB4HJ2c4NnPcmy69'
+
+  # 最初は1ページあたり10件なので11番目のtrは無い
+  expect(page.all('#SelfDisclosuresCard > div > div > div.DataView-Content > div > div > div > table > tbody > tr:nth-child(11)').empty?).to eq true
+
+  # 項目中
+  d = SELF_DISCLOSURES_ITEMS.size
+  expect(find('#SelfDisclosuresCard > div > div > div.DataView-Content > div > div > div.v-data-footer > div.v-data-footer__pagination').text).to eq JA_JSON['DataView_Footer'][1].to_s.gsub('{itemsLength}', d.to_s).gsub('{pageStart}', '1').gsub('{pageStop}', d < 10 ? d.to_s : '10').rstrip
+
+  # １ページあたり10件
+  expect(find('#SelfDisclosuresCard > div > div > div.DataView-Content > div > div > div.v-data-footer > div.v-data-footer__select').text).to eq "#{JA_JSON['DataView_Footer'][0]}\n10"
+
+  # 次のページ
+  find('#SelfDisclosuresCard > div > div > div.DataView-Content > div > div > div.v-data-footer > div.v-data-footer__icons-after > button').click
+
+  # 次のページの先頭は11番目の要素
+  d = "#{SELF_DISCLOSURES_ITEMS[10]['icon']} #{SELF_DISCLOSURES_ITEMS[10]['text']['ja']}"
+  expect(find('#SelfDisclosuresCard > div > div > div.DataView-Content > div > div > div.v-data-table__wrapper > table > tbody > tr:nth-child(1) > td.text-start').text).to eq d.to_s
+
+  # さらに次のページ
+  find('#SelfDisclosuresCard > div > div > div.DataView-Content > div > div > div.v-data-footer > div.v-data-footer__icons-after > button').click
+
+  # さらに次のページの先頭は21番目の要素
+  d = "#{SELF_DISCLOSURES_ITEMS[20]['icon']} #{SELF_DISCLOSURES_ITEMS[20]['text']['ja']}"
+  expect(find('#SelfDisclosuresCard > div > div > div.DataView-Content > div > div > div.v-data-table__wrapper > table > tbody > tr:nth-child(1) > td.text-start').text).to eq d.to_s
 end

--- a/spec/lib/WhatsNewCard.rb
+++ b/spec/lib/WhatsNewCard.rb
@@ -10,6 +10,7 @@ def has_whats_new_card
 
   # テーブルの中身
   NEWS_ITEMS.each_with_index do |d, index|
+    break if index > 9
     # テーブルの上からi行目をチェックする(icon + text)
     if d['url']['ja'].blank?
       expect(page).not_to have_selector("#WhatsNewCard > div > div > div.DataView-Content > div > div > div > table > tbody > tr:nth-child(#{1 + index}) > td:nth-child(1) > a")
@@ -20,5 +21,15 @@ def has_whats_new_card
 
     # テーブルの上からi行目をチェックする(日付)
     expect(find("#WhatsNewCard > div > div > div.DataView-Content > div > div > div > table > tbody > tr:nth-child(#{1 + index}) > td:nth-child(2)").text).to eq Date.parse(d['date']).strftime('%-m月%-d日').to_s
+
+    # 最初は1ページあたり10件なので11番目のtrは無い
+    expect(page.all('#WhatsNewCard > div > div > div.DataView-Content > div > div > div > table > tbody > tr:nth-child(11)').empty?).to eq true
+
+    # 項目中
+    d = NEWS_ITEMS.size
+    expect(find('#WhatsNewCard > div > div > div.DataView-Content > div > div > div.v-data-footer > div.v-data-footer__pagination').text).to eq JA_JSON['DataView_Footer'][1].to_s.gsub('{itemsLength}', d.to_s).gsub('{pageStart}', '1').gsub('{pageStop}', d < 10 ? d.to_s : '10').rstrip
+
+    # １ページあたり10件
+    expect(find('#WhatsNewCard > div > div > div.DataView-Content > div > div > div.v-data-footer > div.v-data-footer__select').text).to eq "#{JA_JSON['DataView_Footer'][0]}\n10"
   end
 end


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1523 

## ⛏ 変更内容 / Details of Changes
- SelfDisclosuresCard.vue 用に Whatsnew.vue から SelfDisclosures.vue に分離
- 情報提供フォームはDataSetPanelの部分に表示する
- Whatsnew と SelfDisclosures に ページネーションを追加
- 関連する spec
