### PR TITLE
陽性者数 > 検査件数 になった場合の 20210214 と 20210505 を特別対応

### DIFF
--- a/spec/lib/PositiveRateCard.rb
+++ b/spec/lib/PositiveRateCard.rb
@@ -28,17 +28,47 @@ def has_positive_rate_card(lang:, lang_json:)
 
   # 検査の陽性率(実際に計算する)
   a = (DAILY_POSITIVE_DETAIL_JSON['data'][-7..].reduce(0) { |sum, n| sum + n['count'].to_i } / 7.0)
-  b = (POSITIVE_RATE_JSON['data'][-7..].reduce(0) { |sum, n| sum + n['pcr_positive_count'].to_i + n['pcr_negative_count'].to_i + n['antigen_positive_count'].to_i + n['antigen_negative_count'].to_i } / 7.0)
+  b = (POSITIVE_RATE_JSON['data'][-7..].reduce(0) { |sum, n| sum + n['pcr_positive_count'].to_i + (
+    if Date.parse(n['diagnosed_date']) == Date.new(2021, 2, 14)
+      # 2021/2/15 に発表された 2021/2/14 のデータについて
+      # https://github.com/MeditationDuck/covid19/issues/1314
+      # 検査件数より陽性件数の方が多く出た。
+      # 本来は pcr_negative は -3 になるが、マイナスにならないように GoogleSheets で 0 に手動で調整したため、
+      # specでの実際の計算では -3 に戻して7日間移動平均を計算する
+      n['pcr_negative_count'].to_i - 3
+    elsif Date.parse(n['diagnosed_date']) == Date.new(2021, 5, 5)
+      # 2021/5/6 に発表された 2021/5/5 のデータについて
+      # https://github.com/MeditationDuck/covid19/issues/1637
+      # 検査件数より陽性件数の方が多く出た。
+      # 本来は pcr_negative は -27 になるが、マイナスにならないように GoogleSheets で 0 に手動で調整したため、
+      # specでの実際の計算では -27 に戻して7日間移動平均を計算する
+      n['pcr_negative_count'].to_i - 27
+    else
+      n['pcr_negative_count'].to_i
+    end
+  ) + n['antigen_positive_count'].to_i + n['antigen_negative_count'].to_i } / 7.0)
   d = number_to_delimited(page.evaluate_script("#{(a / b * 100).round(2)}.toFixed(1)"))
   expect(find('#PositiveRateCard > div > div > div.DataView-Header > div > div:nth-child(1) > div > span > strong').text).to eq d.to_s
 
   # PCR検査の7日間移動平均(実際に計算する)
   d = number_to_delimited((POSITIVE_RATE_JSON['data'][-7..].reduce(0) { |sum, n| sum + n['pcr_positive_count'].to_i + (
-    # 2021/2/15 に発表された 2021/2/14 のデータについて
-    # 検査件数より陽性件数の方が多く出た。
-    # 本来は pcr_negative -3 になるが、マイナスにならないように GoogleSheets で 0 に手動で調整したため、
-    # specでの実際の計算では -3 に戻して7日間移動平均を計算する
-    Date.parse(n['diagnosed_date']) == Date.new(2021, 2, 14) ? n['pcr_negative_count'].to_i - 3 : n['pcr_negative_count'].to_i
+    if Date.parse(n['diagnosed_date']) == Date.new(2021, 2, 14)
+      # 2021/2/15 に発表された 2021/2/14 のデータについて
+      # https://github.com/MeditationDuck/covid19/issues/1314
+      # 検査件数より陽性件数の方が多く出た。
+      # 本来は pcr_negative は -3 になるが、マイナスにならないように GoogleSheets で 0 に手動で調整したため、
+      # specでの実際の計算では -3 に戻して7日間移動平均を計算する
+      n['pcr_negative_count'].to_i - 3
+    elsif Date.parse(n['diagnosed_date']) == Date.new(2021, 5, 5)
+      # 2021/5/6 に発表された 2021/5/5 のデータについて
+      # https://github.com/MeditationDuck/covid19/issues/1637
+      # 検査件数より陽性件数の方が多く出た。
+      # 本来は pcr_negative は -27 になるが、マイナスにならないように GoogleSheets で 0 に手動で調整したため、
+      # specでの実際の計算では -27 に戻して7日間移動平均を計算する
+      n['pcr_negative_count'].to_i - 27
+    else
+      n['pcr_negative_count'].to_i
+    end
   ) } / 7.0).round(1))
   expect(find('#PositiveRateCard > div > div > div.DataView-Header > div > div:nth-child(2) > div > span > strong').text).to eq d.to_s
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1637 

## ⛏ 変更内容 / Details of Changes
- PositiveRate_spec の 20210214 と 20210505 を特別対応
