### PR TITLE
サイドナビゲーションのワクチン接種情報を別ページに分離しました

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -168,8 +168,7 @@ export default Vue.extend({
         {
           iconPath: mdiNeedle,
           title: this.$t('SideNavigation.a[10]'),
-          link:
-            'https://www.pref.iwate.jp/kurashikankyou/iryou/covid19/1037252.html',
+          link: this.localePath('/vaccine'),
         },
         {
           iconPath: mdiAccountMultiple,

--- a/pages/vaccine.vue
+++ b/pages/vaccine.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="Vaccine">
+    <page-header class="mb-3" :icon-path="headerItem.iconPath">
+      <template #pageHeader>
+        {{ headerItem.title }}
+      </template>
+    </page-header>
+    <static-card>
+      <h3>
+        <app-link
+          to="https://www.pref.iwate.jp/kurashikankyou/iryou/covid19/1037252.html"
+          :icon-size="24"
+          >{{ $t('新型コロナウイルスワクチン接種に関する情報') }}
+        </app-link>
+      </h3>
+      <p>
+        {{
+          $t(
+            '県では、新型コロナウイルスワクチンの安全かつ円滑な接種に向けて、市町村や医療機関などと連携し対応しています。'
+          )
+        }}
+      </p>
+    </static-card>
+    <static-card>
+      <h3>
+        <app-link
+          to="https://www.cov19-vaccine.mhlw.go.jp/qa/"
+          :icon-size="24"
+          >{{ $t('新型コロナワクチンQandA') }}
+        </app-link>
+      </h3>
+      <p>
+        {{
+          $t(
+            '新型コロナウイルスワクチンに関する、厚生労働省のWebサイトです。'
+          )
+        }}
+      </p>
+    </static-card>
+    <static-card>
+      <h3>
+        <app-link
+          to="https://v-sys.mhlw.go.jp/"
+          :icon-size="24"
+          >{{
+            $t(
+              'コロナワクチンナビ'
+            )
+          }}
+        </app-link>
+      </h3>
+      <p>
+        {{
+          $t(
+            '新型コロナウイルスワクチン接種に関する、厚生労働省のWebサイトです。'
+          )
+        }}
+      </p>
+    </static-card>
+  </div>
+</template>
+
+<script lang="ts">
+import { mdiNeedle } from '@mdi/js'
+import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
+
+import AppLink from '@/components/AppLink.vue'
+import PageHeader from '@/components/PageHeader.vue'
+import StaticCard from '@/components/StaticCard.vue'
+
+export default Vue.extend({
+  name: 'Vaccine',
+  components: {
+    PageHeader,
+    StaticCard,
+    AppLink,
+  },
+  data() {
+    return {
+      headerItem: {
+        iconPath: mdiNeedle,
+        title: this.$t('SideNavigation.a[10]') as string,
+      },
+    }
+  },
+  head(): MetaInfo {
+    return {
+      title: this.$t('SideNavigation.a[10]') as string,
+    }
+  },
+})
+</script>

--- a/pages/vaccine.vue
+++ b/pages/vaccine.vue
@@ -23,30 +23,20 @@
     </static-card>
     <static-card>
       <h3>
-        <app-link
-          to="https://www.cov19-vaccine.mhlw.go.jp/qa/"
-          :icon-size="24"
+        <app-link to="https://www.cov19-vaccine.mhlw.go.jp/qa/" :icon-size="24"
           >{{ $t('新型コロナワクチンQandA') }}
         </app-link>
       </h3>
       <p>
         {{
-          $t(
-            '新型コロナウイルスワクチンに関する、厚生労働省のWebサイトです。'
-          )
+          $t('新型コロナウイルスワクチンに関する、厚生労働省のWebサイトです。')
         }}
       </p>
     </static-card>
     <static-card>
       <h3>
-        <app-link
-          to="https://v-sys.mhlw.go.jp/"
-          :icon-size="24"
-          >{{
-            $t(
-              'コロナワクチンナビ'
-            )
-          }}
+        <app-link to="https://v-sys.mhlw.go.jp/" :icon-size="24"
+          >{{ $t('コロナワクチンナビ') }}
         </app-link>
       </h3>
       <p>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1660

## 📝 関連する issue / Related Issues
- (なし)

## ⛏ 変更内容 / Details of Changes
- ワクチン接種情報を別ページに分離し、サイドバーの「ワクチン接種」のリンクから飛べるようにしました。

## 📸 スクリーンショット / Screenshots

![img](https://user-images.githubusercontent.com/772589/117508073-f1317a80-afc2-11eb-8b90-72bacbf83470.PNG)
