### PR TITLE
Feature/#1657 画面遷移して戻るとalert itemsの順序が逆に表示されている

### DIFF
--- a/components/CardsReference.vue
+++ b/components/CardsReference.vue
@@ -20,9 +20,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      rows: [
-        [WhatsNewCard, SelfDisclosuresCard],
-      ],
+      rows: [[WhatsNewCard, SelfDisclosuresCard]],
     }
   },
 })

--- a/components/SiteTopUpper.vue
+++ b/components/SiteTopUpper.vue
@@ -23,7 +23,7 @@
     <lazy-static-info
       v-for="(item, i) in alertItems"
       :key="i"
-      class="mb-4"
+      class="mb-4 alertItem"
       :url="item.url"
       :text="item.text"
     />
@@ -32,7 +32,6 @@
 
 <script lang="ts">
 import { mdiChartTimelineVariant } from '@mdi/js'
-import dayjs from 'dayjs'
 import Vue from 'vue'
 
 import PageHeader from '@/components/PageHeader.vue'
@@ -47,21 +46,18 @@ export default Vue.extend({
   data() {
     const { lastUpdate } = Data
 
-    // 日付の新しいものが上
-    const alertItems = Alert.alertItems
-      .sort((a, b) => {
-        return dayjs(a.date).isBefore(dayjs(b.date)) ? 1 : -1
-      })
-      .map((d: any) => {
-        const _locale: string = this.$i18n.locale
-        const _text: string = d.text[_locale] ?? d.text.ja
-        const _url: string = d.url[_locale] ?? d.url.ja
+    // 日付でソートしない
+    // Google Sheets の行の順番で上から並ぶ
+    const alertItems = Alert.alertItems.map((d: any) => {
+      const _locale: string = this.$i18n.locale
+      const _text: string = d.text[_locale] ?? d.text.ja
+      const _url: string = d.url[_locale] ?? d.url.ja
 
-        return {
-          text: _text,
-          url: _url,
-        }
-      })
+      return {
+        text: _text,
+        url: _url,
+      }
+    })
 
     return {
       headerItem: {

--- a/spec/lib/SiteTopUpper.rb
+++ b/spec/lib/SiteTopUpper.rb
@@ -15,16 +15,6 @@ def has_site_top_upper(lang:, data:)
   # 電話相談をどうぞ
   expect(find('.MainPage > a:nth-child(2).StaticInfo.Link').text).to eq "#{lang_json['SiteTopUpper']['電話相談をどうぞ']}\n#{lang_json['SiteTopUpper']['相談の手順を見る']}"
   expect(find('.MainPage > a:nth-child(2).StaticInfo.Link > div.StaticInfo-Button > button').text).to eq lang_json['SiteTopUpper']['相談の手順を見る'].to_s
-  ALERT_ITEMS.each_with_index do |d, index|
-    a = d['text'][lang.to_s] || d['text']['ja']
-    b = d['url'][lang.to_s] || d['url']['ja']
-    # 外部URLの時は .ExternalLink、内部URLの時は .Link
-    c = URI.parse(b).hostname.nil? ? 'Link' : 'ExternalLink'
-    # url が http から始まらない /card/ のような場合はホスト名を補完
-    b = "#{Capybara.app_host}#{b}" if c === 'Link'
-    expect(find(".MainPage > a:nth-child(#{index + 3}).StaticInfo.#{c}").text).to eq a
-    expect(find(".MainPage > a:nth-child(#{index + 3}).StaticInfo.#{c}")['href']).to eq b
-  end
 
   if lang == :ja
     # time
@@ -38,5 +28,30 @@ def has_site_top_upper(lang:, data:)
     # Annotation
     expect(find('.MainPage > .Header > .Annotation > span').text).to eq lang_json['SiteTopUpper']['注釈'].to_s
     expect(URI(find('.MainPage > a:nth-child(2).StaticInfo.Link')['href']).path).to eq "/#{lang}/flow"
+  end
+
+  # 初期表示の時のALERT_ITEMSの順番
+  check_alert_items(lang)
+
+  # 検査要請者の状況の /cards/details-of-confirmed-cases に移動して
+  find('#ConfirmedCasesDetailsCard > div > div > div.DataView-Header > div > div > h3 > a').click
+
+  # その後に左上のログをクリックして / に戻ったら
+  find('#app > div > div.appContainer > div > div > header > h1 > a').click
+
+  # それでもALERT_ITEMSの順番が保たれている
+  check_alert_items(lang)
+end
+
+def check_alert_items(lang)
+  ALERT_ITEMS.each_with_index do |d, index|
+    a = d['text'][lang.to_s] || d['text']['ja']
+    b = d['url'][lang.to_s] || d['url']['ja']
+    # 外部URLの時は .ExternalLink、内部URLの時は .Link
+    c = URI.parse(b).hostname.nil? ? 'Link' : 'ExternalLink'
+    # url が http から始まらない /card/ のような場合はホスト名を補完
+    b = "#{Capybara.app_host}#{b}" if c === 'Link'
+    expect(find(".MainPage > a.alertItem:nth-child(#{index + 3}).StaticInfo.#{c}").text).to eq a
+    expect(find(".MainPage > a.alertItem:nth-child(#{index + 3}).StaticInfo.#{c}")['href']).to eq b
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,7 +98,7 @@ SELF_DISCLOSURES_JSON = JSON.parse(File.read(File.join(__dir__, '../data/self_di
 MAIN_SUMMARY_JSON = JSON.parse(File.read(File.join(__dir__, '../data/main_summary.json')))
 
 NEWS_ITEMS = NEWS_JSON['newsItems'].sort_by.with_index { |v, i| [Date.parse(v['date']), i] }.reverse
-ALERT_ITEMS = ALERT_JSON['alertItems'].sort_by.with_index { |v, i| [Date.parse(v['date']), i] }.reverse
+ALERT_ITEMS = ALERT_JSON['alertItems']
 SELF_DISCLOSURES_ITEMS = SELF_DISCLOSURES_JSON['newsItems'].sort_by.with_index { |v, i| [Date.parse(v['date']), i] }.reverse
 
 LOCALES = {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1657 

## ⛏ 変更内容 / Details of Changes
- alertItems を日付でソートせずに、GoogleSheetの順序のまま扱う
