### PR TITLE
printのh1の翻訳キーがtypo を修正

### DIFF
--- a/layouts/print.vue
+++ b/layouts/print.vue
@@ -13,7 +13,7 @@
           <h1 class="PrintMeta-Heading">
             {{ $t('Common.新型コロナウイルス感染症') }}
             <br />
-            {{ $t('Common.対策サイト非公式') }}
+            {{ $t('Common.対策サイト') }}
           </h1>
         </div>
         <div class="PrintMeta-QRWrapper">

--- a/spec/feature/page/page_print_flow_spec.rb
+++ b/spec/feature/page/page_print_flow_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'iPhone 6/7/8', type: :feature do
+  LOCALES.each do |lang, data|
+    context "page #{data[:path]}" do
+      before do
+        visit "#{data[:path]}print/flow"
+      end
+
+      it 'title' do
+        expect(title).to eq "#{LOCALES[lang][:json]['SideNavigation']['a'][4]}"
+      end
+
+      it 'h1' do
+        expect(find('#app > div > div > div.PrintMeta > div.PrintMeta-HeadingWrapper > h1').text).to eq "#{LOCALES[lang][:json]['Common']['新型コロナウイルス感染症']}\n#{LOCALES[lang][:json]['Common']['対策サイト']}"
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1716 

## ⛏ 変更内容 / Details of Changes
- printのh1の翻訳キーがtypo を修正
- printのh1の翻訳キーがtypo に対する spec

