### PR TITLE
「岩手県新型コロナウイルス感染症対応従事者慰労金交付事業のお知らせ」へのリンクを削除

### DIFF
--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -37,26 +37,6 @@
         }}
       </p>
     </static-card>
-    <static-card>
-      <h3>
-        <app-link
-          to="https://www.pref.iwate.jp/kurashikankyou/iryou/seido/1031487.html"
-          :icon-size="24"
-          >{{
-            $t(
-              '岩手県新型コロナウイルス感染症対応従事者慰労金交付事業のお知らせ'
-            )
-          }}
-        </app-link>
-      </h3>
-      <p>
-        {{
-          $t(
-            '新型コロナウイルス感染症に対する医療提供に関し、岩手県から役割を設定された医療機関等に勤務し患者と接する医療従事者や職員に対し、慰労金として最大20万円を給付します。'
-          )
-        }}
-      </p>
-    </static-card>
   </div>
 </template>
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1736 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- https://iwate.stopcovid19.jp/worker/ から[岩手県新型コロナウイルス感染症対応従事者慰労金交付事業のお知らせ](https://www.pref.iwate.jp/kurashikankyou/iryou/seido/1031487.html) へのリンクを削除する


## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
### Before

cf. https://iwate.stopcovid19.jp/worker/

### After

![スクリーンショット 2021-05-16 13 12 37](https://user-images.githubusercontent.com/23148331/118385256-829a8f80-b648-11eb-9226-5baa46406050.png)
