### PR TITLE
nuxt-i18nにhour12じゃなくてhourCycle: 'h23' を指定する

### DIFF
--- a/nuxt-i18n.config.ts
+++ b/nuxt-i18n.config.ts
@@ -8,7 +8,7 @@ const dateTimeFormatsCommon: DateTimeFormat = {
     day: 'numeric',
     hour: 'numeric',
     minute: 'numeric',
-    hour12: false,
+    hourCycle: 'h23',
   },
   date: {
     year: 'numeric',


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1751 

## ⛏ 変更内容 / Details of Changes
- `hour12: false` から `hourCycle: 'h23'` に変更
