### PR TITLE
og:url の末尾が `//` になってるのを `/` に修正

### DIFF
--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -174,7 +174,7 @@ export default {
         {
           hid: 'og:url',
           property: 'og:url',
-          content: `${url}${this.$route.path}/`,
+          content: `${url}${this.$route.path}`,
         },
         {
           hid: 'og:title',

--- a/spec/feature/cards/cards_ConfirmedCasesAttributesCard_spec.rb
+++ b/spec/feature/cards/cards_ConfirmedCasesAttributesCard_spec.rb
@@ -23,6 +23,13 @@ describe 'iPhone 6/7/8', type: :feature do
         # JS解釈しないog:title
         expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/attributes-of-confirmed-cases/").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:url' do
+        # JS解釈したog:url
+        expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp/cards/attributes-of-confirmed-cases/"
+        # JS解釈しないog:url
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/attributes-of-confirmed-cases/").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp/cards/attributes-of-confirmed-cases/"
+      end
     end
 
     describe '陽性者の属性(ConfirmedCasesAttributesCard)' do

--- a/spec/feature/cards/cards_ConfirmedCasesByMunicipalitiesCard_spec.rb
+++ b/spec/feature/cards/cards_ConfirmedCasesByMunicipalitiesCard_spec.rb
@@ -24,6 +24,13 @@ describe 'iPhone 6/7/8', type: :feature do
           # JS解釈しないog:title
           expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/number-of-confirmed-cases-by-municipalities/").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
         end
+
+        it 'og:url' do
+          # JS解釈したog:url
+          expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp#{data[:path]}cards/number-of-confirmed-cases-by-municipalities/"
+          # JS解釈しないog:url
+          expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}#{data[:path]}cards/number-of-confirmed-cases-by-municipalities/").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp#{data[:path]}cards/number-of-confirmed-cases-by-municipalities/"
+        end
       end
 
       describe '陽性患者数(市町村別)(ConfirmedCasesByMunicipalitiesCard)' do

--- a/spec/feature/cards/cards_ConfirmedCasesDetailsCard_spec.rb
+++ b/spec/feature/cards/cards_ConfirmedCasesDetailsCard_spec.rb
@@ -24,6 +24,13 @@ describe 'iPhone 6/7/8', type: :feature do
           # JS解釈しないog:title
           expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/details-of-confirmed-cases/").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
         end
+
+        it 'og:url' do
+          # JS解釈したog:url
+          expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp#{data[:path]}cards/details-of-confirmed-cases/"
+          # JS解釈しないog:url
+          expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}#{data[:path]}cards/details-of-confirmed-cases/").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp#{data[:path]}cards/details-of-confirmed-cases/"
+        end
       end
 
       describe '検査陽性者の状況(ConfirmedCasesDetailsCard)' do

--- a/spec/feature/cards/cards_ConfirmedCasesNumberCard_spec.rb
+++ b/spec/feature/cards/cards_ConfirmedCasesNumberCard_spec.rb
@@ -23,6 +23,13 @@ describe 'iPhone 6/7/8', type: :feature do
         # JS解釈しないog:title
         expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/number-of-confirmed-cases/").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:url' do
+        # JS解釈したog:url
+        expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp/cards/number-of-confirmed-cases/"
+        # JS解釈しないog:url
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/number-of-confirmed-cases/").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp/cards/number-of-confirmed-cases/"
+      end
     end
 
     describe '報告日別による陽性者数の推移(ConfirmedCasesNumberCard)' do

--- a/spec/feature/cards/cards_HospitalizedNumberCard_spec.rb
+++ b/spec/feature/cards/cards_HospitalizedNumberCard_spec.rb
@@ -23,6 +23,13 @@ describe 'iPhone 6/7/8', type: :feature do
         # JS解釈しないog:title
         expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/number-of-hospitalized/").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:url' do
+        # JS解釈したog:url
+        expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp/cards/number-of-hospitalized/"
+        # JS解釈しないog:url
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/number-of-hospitalized/").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp/cards/number-of-hospitalized/"
+      end
     end
 
     describe '入院と宿泊療養の推移(HospitalizedNumberCard)' do

--- a/spec/feature/cards/cards_MonitoringConfirmedCasesNumberCard_spec.rb
+++ b/spec/feature/cards/cards_MonitoringConfirmedCasesNumberCard_spec.rb
@@ -23,6 +23,13 @@ describe 'iPhone 6/7/8', type: :feature do
         # JS解釈しないog:title
         expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/monitoring-number-of-confirmed-cases/").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:url' do
+        # JS解釈したog:url
+        expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp/cards/monitoring-number-of-confirmed-cases/"
+        # JS解釈しないog:url
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/monitoring-number-of-confirmed-cases/").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp/cards/monitoring-number-of-confirmed-cases/"
+      end
     end
 
     describe '新規陽性者数の7日間移動平均(MonitoringConfirmedCasesNumberCard)' do

--- a/spec/feature/cards/cards_PositiveRateCard_spec.rb
+++ b/spec/feature/cards/cards_PositiveRateCard_spec.rb
@@ -24,6 +24,13 @@ describe 'iPhone 6/7/8', type: :feature do
           # JS解釈しないog:title
           expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}#{data[:path]}cards/positive-rate/").open).css('head meta[property="og:title"]').first['content']).to eq "#{LOCALES[lang][:json]['Common']['岩手県']} #{LOCALES[lang][:json]['Common']['新型コロナウイルス感染症']}#{LOCALES[lang][:json]['Common']['対策サイト']}"
         end
+
+        it 'og:url' do
+          # JS解釈したog:url
+          expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp#{data[:path]}cards/positive-rate/"
+          # JS解釈しないog:url
+          expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}#{data[:path]}cards/positive-rate/").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp#{data[:path]}cards/positive-rate/"
+        end
       end
 
       describe '検査の陽性率(PositiveRateCard)' do

--- a/spec/feature/cards/cards_SelfDisclosuresCard_spec.rb
+++ b/spec/feature/cards/cards_SelfDisclosuresCard_spec.rb
@@ -24,6 +24,13 @@ describe 'iPhone 6/7/8', type: :feature do
           # JS解釈しないog:title
           expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}#{data[:path]}cards/self-disclosures/").open).css('head meta[property="og:title"]').first['content']).to eq "#{LOCALES[lang][:json]['Common']['岩手県']} #{LOCALES[lang][:json]['Common']['新型コロナウイルス感染症']}#{LOCALES[lang][:json]['Common']['対策サイト']}"
         end
+
+        it 'og:url' do
+          # JS解釈したog:url
+          expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp#{data[:path]}cards/self-disclosures/"
+          # JS解釈しないog:url
+          expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}#{data[:path]}cards/self-disclosures/").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp#{data[:path]}cards/self-disclosures/"
+        end
       end
 
       describe '自主公表(SelfDisclosuresCard)' do

--- a/spec/feature/cards/cards_TestedNumberCard_spec.rb
+++ b/spec/feature/cards/cards_TestedNumberCard_spec.rb
@@ -23,6 +23,13 @@ describe 'iPhone 6/7/8', type: :feature do
         # JS解釈しないog:title
         expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/number-of-tested/").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:url' do
+        # JS解釈したog:url
+        expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp/cards/number-of-tested/"
+        # JS解釈しないog:url
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/number-of-tested/").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp/cards/number-of-tested/"
+      end
     end
 
     describe '検査実施件数(TestedNumberCard)' do

--- a/spec/feature/cards/cards_UntrackedRateCard_spec.rb
+++ b/spec/feature/cards/cards_UntrackedRateCard_spec.rb
@@ -23,6 +23,13 @@ describe 'iPhone 6/7/8', type: :feature do
         # JS解釈しないog:title
         expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/untracked-rate/").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:url' do
+        # JS解釈したog:url
+        expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp/cards/untracked-rate/"
+        # JS解釈しないog:url
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/untracked-rate/").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp/cards/untracked-rate/"
+      end
     end
 
     describe '接触歴等不明者数(7日間移動平均)(UntrackedRateCard)' do

--- a/spec/feature/cards/cards_WeeklyMapCard_spec.rb
+++ b/spec/feature/cards/cards_WeeklyMapCard_spec.rb
@@ -24,6 +24,13 @@ describe 'iPhone 6/7/8', type: :feature do
           # JS解釈しないog:title
           expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}#{data[:path]}cards/weekly-map/").open).css('head meta[property="og:title"]').first['content']).to eq "#{LOCALES[lang][:json]['Common']['岩手県']} #{LOCALES[lang][:json]['Common']['新型コロナウイルス感染症']}#{LOCALES[lang][:json]['Common']['対策サイト']}"
         end
+
+        it 'og:url' do
+          # JS解釈したog:url
+          expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp#{data[:path]}cards/weekly-map/"
+          # JS解釈しないog:url
+          expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}#{data[:path]}cards/weekly-map/").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp#{data[:path]}cards/weekly-map/"
+        end
       end
 
       describe '直近1週間の陽性例マップ(WeeklyMapCard)' do

--- a/spec/feature/cards/cards_WhatsNewCard_spec.rb
+++ b/spec/feature/cards/cards_WhatsNewCard_spec.rb
@@ -23,6 +23,13 @@ describe 'iPhone 6/7/8', type: :feature do
         # JS解釈しないog:title
         expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/whats-new/").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
       end
+
+      it 'og:url' do
+        # JS解釈したog:url
+        expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp/cards/whats-new/"
+        # JS解釈しないog:url
+        expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}/cards/whats-new/").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp/cards/whats-new/"
+      end
     end
 
     describe '最新のお知らせ(WhatsNewCard)' do

--- a/spec/feature/index/index_h1h2_spec.rb
+++ b/spec/feature/index/index_h1h2_spec.rb
@@ -20,6 +20,13 @@ describe 'iPhone 6/7/8', type: :feature do
       expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}").open).css('head meta[property="og:title"]').first['content']).to eq "#{JA_JSON['Common']['岩手県']} #{JA_JSON['Common']['新型コロナウイルス感染症']}#{JA_JSON['Common']['対策サイト']}"
     end
 
+    it 'og:url' do
+      # JS解釈したog:url
+      expect(find('head meta[property="og:url"]', visible: false)[:content]).to eq "https://iwate.stopcovid19.jp/"
+      # JS解釈しないog:url
+      expect(Nokogiri::HTML(URI.parse("#{Capybara.app_host}").open).css('head meta[property="og:url"]').first['content']).to eq "https://iwate.stopcovid19.jp/"
+    end
+
     it 'h1/h2' do
       expect(find('#app > div > div.appContainer > div > div > header > h1').text).to eq "#{JA_JSON['Common']['新型コロナウイルス感染症']}\n#{JA_JSON['Common']['対策サイト']}"
       expect(find('#app > div > div.appContainer > main > div > div > div.MainPage > div.Header.mb-3 > div.header > h2').text).to eq (JA_JSON['Common']['岩手の最新感染動向']).to_s

--- a/utils/i18nUtils.ts
+++ b/utils/i18nUtils.ts
@@ -10,9 +10,9 @@ export const getLinksLanguageAlternative = (
   const getFullPathWihLocale = (locale: string) => {
     const pathLocale = locale === 'ja' ? '' : `/${locale}`
     if (routeBaseName === 'index') {
-      return `https://iwate.stopcovid19.jp${pathLocale}`
+      return `https://iwate.stopcovid19.jp${pathLocale}/`
     } else {
-      return `https://iwate.stopcovid19.jp${pathLocale}/${routeBaseName}`
+      return `https://iwate.stopcovid19.jp${pathLocale}/${routeBaseName}/`
     }
   }
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1763 

## ⛏ 変更内容 / Details of Changes
- og:url の末尾を `//` から `/` に修正
- og:url の末尾を `//` から `/` に修正 に対する spec
- ついでに alternate-hreflang- の末尾に `/` を追加

