### PR TITLE
シェアシートのpermalinkの末尾に`/`をつける

### DIFF
--- a/components/DataViewShare.vue
+++ b/components/DataViewShare.vue
@@ -177,7 +177,7 @@ export default Vue.extend({
       e.stopPropagation()
     },
     permalink(host: boolean = false, embed: boolean = false) {
-      let permalink = `/cards/${this.titleId}`
+      let permalink = `/cards/${this.titleId}/`
       if (embed) {
         permalink = `${permalink}?embed=true`
       }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1726 

## ⛏ 変更内容 / Details of Changes
- シェアシートのpermalinkの末尾に`/`をつける
