### PR TITLE
en の OGP画像のurlを修正

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -207,7 +207,7 @@
   "2次元コード": "QR Code",
   "※最新の情報はWebページをご覧ください": "* Please check the latest information from the website.",
   "ogp": {
-    "og:image": "https://iwate.stopcovid19.jp/ogp/en/ogp-image.png"
+    "og:image": "https://iwate.stopcovid19.jp/ogp.png"
   },
   "{title}のグラフをシェア": "Share the graph of {title}",
   "閉じる": "Close",


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #1681 

## ⛏ 変更内容 / Details of Changes
- enのOGP画像のURLが404だったので、日本語版のURLをとりあえず指定
