### PR TITLE
municipalitiesのtable内はnumber_to_delimitedしない

### DIFF
--- a/spec/lib/ConfirmedCasesByMunicipalitiesCard.rb
+++ b/spec/lib/ConfirmedCasesByMunicipalitiesCard.rb
@@ -24,7 +24,7 @@ def has_confirmed_cases_by_municipalities_card(lang:, lang_json:)
 
   # テーブルの上から1行目をチェックする(陽性者数)
   expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(2)').text).to eq lang_json['ConfirmedCasesByMunicipalitiesCard']['legends'][1]
-  d = number_to_delimited(PATIENT_MUNICIPALITIES_JSON['datasets']['data'].first['count'])
+  d = PATIENT_MUNICIPALITIES_JSON['datasets']['data'].first['count']
   expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(1) > td:nth-child(2)').text).to eq d.to_s
 
   # テーブルの上から1行目をチェックする(対人口)
@@ -34,12 +34,10 @@ def has_confirmed_cases_by_municipalities_card(lang:, lang_json:)
 
   # テーブルの上から1行目をチェックする(直近1週間)
   expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > thead > tr > th:nth-child(4)').text).to eq lang_json['ConfirmedCasesByMunicipalitiesCard']['legends'][3]
-  d = number_to_delimited(
-    DATA_JSON['patients']['data']
+  d = DATA_JSON['patients']['data']
       .select { | item | item['居住地'] == PATIENT_MUNICIPALITIES_JSON['datasets']['data'].first['label'] }
       .select { |item| Date.parse(item['確定日']) > Date.parse(DATA_JSON['patients_summary']['data'].last['日付']) - 8 }
       .count
-  )
   expect(find('#ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Content > div > div > table > tbody > tr:nth-child(1) > td:nth-child(4)').text).to eq d.to_s
 
   # テーブルの上から1行目をチェックする(直近1週間対人口10万人)


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #1105 

## ⛏ 変更内容 / Details of Changes
- municipalitiesのtable内はnumber_to_delimitedしないでテストする
