### PR TITLE
chartから id:'day' を非表示にする

### DIFF
--- a/components/index/CardsMonitoring/AgeGroup/Chart.vue
+++ b/components/index/CardsMonitoring/AgeGroup/Chart.vue
@@ -288,6 +288,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
+              id: 'day',
+            },
+            {
               id: 'month',
               stacked: true,
               gridLines: {
@@ -355,6 +359,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         tooltips: { enabled: false },
         scales: {
           xAxes: [
+            {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
+              id: 'day',
+            },
             {
               id: 'month',
               stacked: true,

--- a/components/index/CardsMonitoring/EffectiveReproductionNumber/Chart.vue
+++ b/components/index/CardsMonitoring/EffectiveReproductionNumber/Chart.vue
@@ -291,22 +291,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: '#808080',
-                maxRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
-              // #2384: If you set "type" to "time", make sure that the bars at both ends are not hidden.
-              // #2384: typeをtimeに設定する時はグラフの両端が見切れないか確認してください
             },
             {
               id: 'month',
@@ -392,19 +379,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: 'transparent',
-                maxRotation: 0,
-                minRotation: 0,
-                callback: (label: string) => dayjs(label).format('D'),
-              },
             },
             {
               id: 'month',

--- a/components/index/CardsMonitoring/HospitalizedNumber/Chart.vue
+++ b/components/index/CardsMonitoring/HospitalizedNumber/Chart.vue
@@ -325,22 +325,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: '#808080',
-                maxRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
-              // #2384: If you set "type" to "time", make sure that the bars at both ends are not hidden.
-              // #2384: typeをtimeに設定する時はグラフの両端が見切れないか確認してください
             },
             {
               id: 'month',
@@ -438,21 +425,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: 'transparent',
-                maxRotation: 0,
-                minRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
             },
             {
               id: 'month',

--- a/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Chart.vue
+++ b/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Chart.vue
@@ -337,22 +337,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: '#808080',
-                maxRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
-              // #2384: If you set "type" to "time", make sure that the bars at both ends are not hidden.
-              // #2384: typeをtimeに設定する時はグラフの両端が見切れないか確認してください
             },
             {
               id: 'month',
@@ -446,19 +433,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: 'transparent',
-                maxRotation: 0,
-                minRotation: 0,
-                callback: (label: string) => dayjs(label).format('D'),
-              },
             },
             {
               id: 'month',

--- a/components/index/CardsMonitoring/MonitoringConfirmedCasesNumberPer100k/Chart.vue
+++ b/components/index/CardsMonitoring/MonitoringConfirmedCasesNumberPer100k/Chart.vue
@@ -339,26 +339,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: '#808080',
-                maxRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
-              // #2384: If you set "type" to "time", make sure that the bars at both ends are not hidden.
-              // #2384: typeをtimeに設定する時はグラフの両端が見切れないか確認してください
             },
             {
               id: 'month',
-              stacked: true,
               gridLines: {
                 drawOnChartArea: false,
                 drawTicks: true,
@@ -481,19 +467,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: 'transparent',
-                maxRotation: 0,
-                minRotation: 0,
-                callback: (label: string) => dayjs(label).format('D'),
-              },
             },
             {
               id: 'month',

--- a/components/index/CardsMonitoring/PositiveRate/Chart.vue
+++ b/components/index/CardsMonitoring/PositiveRate/Chart.vue
@@ -436,22 +436,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: '#808080',
-                maxRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
-              // #2384: If you set "type" to "time", make sure that the bars at both ends are not hidden.
-              // #2384: typeをtimeに設定する時はグラフの両端が見切れないか確認してください
             },
             {
               id: 'month',
@@ -582,21 +569,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: 'transparent',
-                maxRotation: 0,
-                minRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
             },
             {
               id: 'month',

--- a/components/index/CardsMonitoring/UntrackedRate/Chart.vue
+++ b/components/index/CardsMonitoring/UntrackedRate/Chart.vue
@@ -371,22 +371,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: '#808080',
-                maxRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
-              // #2384: If you set "type" to "time", make sure that the bars at both ends are not hidden.
-              // #2384: typeをtimeに設定する時はグラフの両端が見切れないか確認してください
             },
             {
               id: 'month',
@@ -478,21 +465,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false, // day軸は非表示にしたいが、削除すると#2384のように見切れるので残す workaround
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: 'transparent',
-                maxRotation: 0,
-                minRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
             },
             {
               id: 'month',

--- a/components/index/_shared/TimeBarChart.vue
+++ b/components/index/_shared/TimeBarChart.vue
@@ -307,22 +307,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false,
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: '#808080',
-                maxRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
-              // #2384: If you set "type" to "time", make sure that the bars at both ends are not hidden.
-              // #2384: typeをtimeに設定する時はグラフの両端が見切れないか確認してください
             },
             {
               id: 'month',
@@ -404,21 +391,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false,
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: 'transparent',
-                maxRotation: 0,
-                minRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
             },
             {
               id: 'month',
@@ -434,24 +409,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 fontColor: 'transparent', // #808080
                 padding: 13, // 3 + 10(tickMarkLength)
                 fontStyle: 'bold',
-                callback: (label: string) => {
-                  const monthStringArry = [
-                    'Jan',
-                    'Feb',
-                    'Mar',
-                    'Apr',
-                    'May',
-                    'Jun',
-                    'Jul',
-                    'Aug',
-                    'Sep',
-                    'Oct',
-                    'Nov',
-                    'Dec',
-                  ]
-                  const month = monthStringArry.indexOf(label.split(' ')[0]) + 1
-                  return month + '月'
-                },
               },
               type: 'time',
               time: {

--- a/components/index/_shared/TimeStackedBarChart.vue
+++ b/components/index/_shared/TimeStackedBarChart.vue
@@ -372,22 +372,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false,
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: '#808080',
-                maxRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
-              // #2384: If you set "type" to "time", make sure that the bars at both ends are not hidden.
-              // #2384: typeをtimeに設定する時はグラフの両端が見切れないか確認してください
             },
             {
               id: 'month',
@@ -473,21 +460,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         scales: {
           xAxes: [
             {
+              display: false,
               id: 'day',
               stacked: true,
-              gridLines: {
-                display: false,
-              },
-              ticks: {
-                fontSize: 9,
-                maxTicksLimit: 20,
-                fontColor: 'transparent',
-                maxRotation: 0,
-                minRotation: 0,
-                callback: (label: string) => {
-                  return dayjs(label).format('D')
-                },
-              },
             },
             {
               id: 'month',
@@ -503,24 +478,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 fontColor: 'transparent', // #808080
                 padding: 13, // 3 + 10(tickMarkLength)
                 fontStyle: 'bold',
-                callback: (label: string) => {
-                  const monthStringArry = [
-                    'Jan',
-                    'Feb',
-                    'Mar',
-                    'Apr',
-                    'May',
-                    'Jun',
-                    'Jul',
-                    'Aug',
-                    'Sep',
-                    'Oct',
-                    'Nov',
-                    'Dec',
-                  ]
-                  const month = monthStringArry.indexOf(label.split(' ')[0]) + 1
-                  return `${month}月`
-                },
               },
               type: 'time',
               time: {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2265 

## 📝 関連する issue / Related Issues
- https://github.com/tokyo-metropolitan-gov/covid19/issues/2384

## ⛏ 変更内容 / Details of Changes
- day軸は生成はするが非表示にする。
- 削除すると https://github.com/tokyo-metropolitan-gov/covid19/issues/2384 のように見切れる問題が発生する

