### PR TITLE
対人口10万人グラフに県独自の緊急事態宣言の解除annotationを追加

### DIFF
--- a/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Chart.vue
+++ b/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Chart.vue
@@ -388,7 +388,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           drawTime: 'afterDatasetsDraw',
           annotations: [
             {
-              id: 'stage3', // optional
+              id: 'iwate_kinkyujitai', // optional
               type: 'line',
               mode: 'horizontal',
               scaleID: 'monitoring-number-of-confirmed-cases',

--- a/components/index/CardsMonitoring/MonitoringConfirmedCasesNumberPer100k/Chart.vue
+++ b/components/index/CardsMonitoring/MonitoringConfirmedCasesNumberPer100k/Chart.vue
@@ -439,6 +439,24 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 xAdjust: this.$nuxt.$vuetify.breakpoint.smAndDown ? 40 : 110,
               },
             },
+            {
+              id: 'iwate_kinkyujitai', // optional
+              type: 'line',
+              mode: 'horizontal',
+              scaleID: 'number-of-confirmed-cases-per-100k',
+              value: '10',
+              borderColor: 'rgba(33,33,33,0.5)',
+              borderWidth: 2,
+              label: {
+                backgroundColor: 'rgba(33,33,33,0.5)',
+                content: this.$t(
+                  'MonitoringConfirmedCasesNumberCard.県独自の緊急事態宣言の解除'
+                ) as string,
+                enabled: true,
+                position: 'right',
+                xAdjust: this.$nuxt.$vuetify.breakpoint.smAndDown ? 50 : 123,
+              },
+            },
           ],
         },
       }

--- a/components/index/CardsMonitoring/MonitoringConfirmedCasesNumberPer100k/Chart.vue
+++ b/components/index/CardsMonitoring/MonitoringConfirmedCasesNumberPer100k/Chart.vue
@@ -414,7 +414,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               borderColor: 'rgba(33,33,33,0.5)',
               borderWidth: 2,
               label: {
-                backgroundColor: 'rgba(33,33,33,0.5)',
+                backgroundColor: 'rgba(204,102,102,0.5)',
                 content: this.$t('Common.ステージ4') as string,
                 enabled: true,
                 position: 'right',


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #2188 

## ⛏ 変更内容 / Details of Changes
- 対人口10万人グラフに県独自の緊急事態宣言の解除annotationを追加
