### PR TITLE
Update check broken links

### DIFF
--- a/spec/feature/check_broken_links_spec.rb
+++ b/spec/feature/check_broken_links_spec.rb
@@ -20,7 +20,7 @@ describe 'iPhone 6/7/8', type: :feature do
     # news.json の 個別ページのURL は直接読み込む
     NEWS_JSON['newsItems'].each do |item|
       urls << URI(item['url']['ja']) unless item['url']['ja'].blank? || item['url']['ja'].match(/www\.youtube\.com/)
-      urls << URI(item['url']['en']) unless item['url']['en'].blank? || item['url']['ja'].match(/www\.youtube\.com/)
+      urls << URI(item['url']['en']) unless item['url']['en'].blank? || item['url']['en'].match(/www\.youtube\.com/)
     end
 
     # alert.json の 個別ページのURL は直接読み込む


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2421 

## ⛏ 変更内容 / Details of Changes
- `https://support.google.com/analytics/answer/6004245?hl=ja`がheadリクエストで404を返すようになったのでgetリクエストする
- youtube.com は404チェックしない

