### PR TITLE
stylelint 9.0.3 で at-rule-empty-line-before がデフォルト設定に戻った

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: ['stylelint-config-standard', 'stylelint-config-prettier'],
   plugins: ['stylelint-scss'],
   rules: {
-    'at-rule-empty-line-before': null,
     'at-rule-no-unknown': null,
     'rule-empty-line-before': null,
     'scss/at-rule-no-unknown': true,


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #2431 

## ⛏ 変更内容 / Details of Changes
- https://github.com/prettier/stylelint-config-prettier/pull/129/commits/d852c75910c0fe7c6ca97672a6d6639df1289861
- stylelintのデフォルト設定に入ったので、独自の設定からは削除

