### PR TITLE
per100kチャートのyaxisのmaxを50に設定

### DIFF
--- a/components/index/CardsFeatured/MonitoringConfirmedCasesNumberPer100k/Chart.vue
+++ b/components/index/CardsFeatured/MonitoringConfirmedCasesNumberPer100k/Chart.vue
@@ -523,7 +523,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       // return this.chartData.reduce((max, data) => {
       //   return Math.max(max, ...data.map((a) => Math.ceil(a))) + 10
       // }, 0)
-      return 35
+      return 50
     },
   },
   methods: {


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #2538 

## ⛏ 変更内容 / Details of Changes
- per100k の max を 50 に設定
