### PR TITLE
カード単体表示 かつ breakpoint.mdAndUp (タブレット横以上)のときグラフの初期表示期間を２倍（120日分）にする

### DIFF
--- a/components/index/CardsFeatured/ConfirmedCasesArea/Card.vue
+++ b/components/index/CardsFeatured/ConfirmedCasesArea/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="ConfirmedCasesAreaCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="ConfirmedCasesAreaCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <confirmed-cases-area-chart
         title-id="confirmed-cases-area"
@@ -11,6 +16,7 @@
         :labels="labels7MA"
         :data-labels="areaLabels"
         :table-labels="areaLabels"
+        :day-period="isSingleCard && $vuetify.breakpoint.mdAndUp ? 120 : 60"
       >
         <template #notes>
           <ul>
@@ -36,6 +42,7 @@ import { TranslateResult } from 'vue-i18n'
 import ConfirmedCasesAreaChart from '@/components/index/CardsFeatured/ConfirmedCasesArea/Chart.vue'
 import ConfirmedCaseArea from '@/data/confirmed_case_area.json'
 import { getNumberToFixedFunction } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 type DataType = {
   areaLabels: string[] | TranslateResult[]
@@ -47,7 +54,9 @@ type DataType = {
 
 type MethodsType = {}
 
-type ComputedType = {}
+type ComputedType = {
+  isSingleCard: boolean
+}
 
 type PropsType = {}
 
@@ -135,6 +144,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       labels7MA,
       chartData7MA,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 

--- a/components/index/CardsFeatured/ConfirmedCasesArea/Card.vue
+++ b/components/index/CardsFeatured/ConfirmedCasesArea/Card.vue
@@ -33,9 +33,9 @@ import Vue from 'vue'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import { TranslateResult } from 'vue-i18n'
 
-import ConfirmedCasesAreaChart from '~/components/index/CardsFeatured/ConfirmedCasesArea/Chart.vue'
-import ConfirmedCaseArea from '~/data/confirmed_case_area.json'
-import { getNumberToFixedFunction } from '~/utils/monitoringStatusValueFormatters'
+import ConfirmedCasesAreaChart from '@/components/index/CardsFeatured/ConfirmedCasesArea/Chart.vue'
+import ConfirmedCaseArea from '@/data/confirmed_case_area.json'
+import { getNumberToFixedFunction } from '@/utils/monitoringStatusValueFormatters'
 
 type DataType = {
   areaLabels: string[] | TranslateResult[]

--- a/components/index/CardsFeatured/ConfirmedCasesDetails/Card.vue
+++ b/components/index/CardsFeatured/ConfirmedCasesDetails/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="ConfirmedCasesDetailsCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="ConfirmedCasesDetailsCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <data-view
         :title="$t('ConfirmedCasesDetailsCard.title')"
@@ -47,6 +52,7 @@ import NotesExpansionPanel from '@/components/index/_shared/DataView/NotesExpans
 import DataViewDataSetPanel from '@/components/index/_shared/DataViewDataSetPanel.vue'
 import ConfirmedCasesDetailsTable from '@/components/index/CardsFeatured/ConfirmedCasesDetails/Table.vue'
 import MainSummary from '@/data/main_summary.json'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -70,6 +76,11 @@ export default {
       MainSummary,
       updatedAt,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsFeatured/HealthBurden/Card.vue
+++ b/components/index/CardsFeatured/HealthBurden/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="HealthBurdenCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="HealthBurdenCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <health-burden-table
         :info-titles="[$t('HealthBurdenCard.title')]"
@@ -26,6 +31,7 @@ import Vue from 'vue'
 
 import HealthBurdenTable from '@/components/index/CardsFeatured/HealthBurden/Table.vue'
 import HealthBurden from '@/data/health_burden.json'
+import { isSingleCard } from '@/utils/urls'
 
 export default Vue.extend({
   components: {
@@ -43,6 +49,11 @@ export default Vue.extend({
       date,
       HealthBurden,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 })
 </script>

--- a/components/index/CardsFeatured/HomeCapacity/Card.vue
+++ b/components/index/CardsFeatured/HomeCapacity/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="HomeCapacityCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="HomeCapacityCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <home-capacity-beds
         :title="$t('HomeCapacityCard.title')"
@@ -35,6 +40,7 @@ import AppLink from '@/components/_shared/AppLink.vue'
 import HomeCapacityBeds from '@/components/index/CardsFeatured/HomeCapacity/Beds.vue'
 import MainSummary from '@/data/main_summary.json'
 import PositiveStatus from '@/data/positive_status.json'
+import { isSingleCard } from '@/utils/urls'
 
 export default Vue.extend({
   components: {
@@ -59,6 +65,11 @@ export default Vue.extend({
       date,
       bedSummary,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 })
 </script>

--- a/components/index/CardsFeatured/HospitalCapacity/Card.vue
+++ b/components/index/CardsFeatured/HospitalCapacity/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="HospitalCapacityCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="HospitalCapacityCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <hospital-capacity-beds
         :title="$t('HospitalCapacityCard.title')"
@@ -50,6 +55,7 @@ import AppLink from '@/components/_shared/AppLink.vue'
 import HospitalCapacityBeds from '@/components/index/CardsFeatured/HospitalCapacity/Beds.vue'
 import MainSummary from '@/data/main_summary.json'
 import PositiveStatus from '@/data/positive_status.json'
+import { isSingleCard } from '@/utils/urls'
 
 export default Vue.extend({
   components: {
@@ -78,6 +84,11 @@ export default Vue.extend({
       date,
       bedSummary,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 })
 </script>

--- a/components/index/CardsFeatured/HotelCapacity/Card.vue
+++ b/components/index/CardsFeatured/HotelCapacity/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="HotelCapacityCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="HotelCapacityCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <hotel-capacity-beds
         :title="$t('HotelCapacityCard.title')"
@@ -50,6 +55,7 @@ import AppLink from '@/components/_shared/AppLink.vue'
 import HotelCapacityBeds from '@/components/index/CardsFeatured/HotelCapacity/Beds.vue'
 import MainSummary from '@/data/main_summary.json'
 import PositiveStatus from '@/data/positive_status.json'
+import { isSingleCard } from '@/utils/urls'
 
 export default Vue.extend({
   components: {
@@ -76,6 +82,11 @@ export default Vue.extend({
       date,
       bedSummary,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 })
 </script>

--- a/components/index/CardsFeatured/MonitoringConfirmedCasesNumberPer100k/Card.vue
+++ b/components/index/CardsFeatured/MonitoringConfirmedCasesNumberPer100k/Card.vue
@@ -2,7 +2,7 @@
   <v-col
     id="MonitoringConfirmedCasesNumberPer100kCard"
     cols="12"
-    :md="md"
+    :md="isSingleCard || md"
     class="DataCard"
   >
     <client-only>
@@ -17,6 +17,7 @@
         :data-labels="dataLabels"
         :table-labels="tableLabels"
         :unit="$t('Common.人')"
+        :day-period="isSingleCard && $vuetify.breakpoint.mdAndUp ? 120 : 60"
       >
         <template #selectCity>
           <v-select
@@ -56,6 +57,7 @@ import {
   getNumberToFixedFunction,
   getNumberToLocaleStringFunction,
 } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 type SelectItem = {
   text: string
@@ -79,6 +81,7 @@ type ComputedType = {
   labels: string[]
   chartData: number[][]
   population: number
+  isSingleCard: boolean
 }
 
 type PropsType = {}
@@ -256,6 +259,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reduce((accumulator, currentValue, _index, _array) => {
           return accumulator + currentValue
         }, 0)
+    },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
   methods: {

--- a/components/index/CardsFeatured/Stage/Card.vue
+++ b/components/index/CardsFeatured/Stage/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col id="StageCard" cols="12" :md="md" class="DataCard">
+  <v-col id="StageCard" cols="12" :md="isSingleCard || md" class="DataCard">
     <client-only>
       <stage-table
         :date="date"
@@ -32,13 +32,16 @@ import Data from '@/data/data.json'
 import MainSummary from '@/data/main_summary.json'
 import PositiveRate from '@/data/positive_rate.json'
 import { getNumberToFixedFunction } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 type DataType = {
   date: string
   tableData: number[]
 }
 type MethodsType = {}
-type ComputedType = {}
+type ComputedType = {
+  isSingleCard: boolean
+}
 type PropsType = {}
 
 const options: ThisTypedComponentOptionsWithRecordProps<
@@ -155,6 +158,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       getFormatter,
       tableData,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 

--- a/components/index/CardsMonitoring/AgeGroup/Card.vue
+++ b/components/index/CardsMonitoring/AgeGroup/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col id="AgeGroupCard" cols="12" :md="md" class="DataCard">
+  <v-col id="AgeGroupCard" cols="12" :md="isSingleCard || md" class="DataCard">
     <client-only>
       <age-chart
         title-id="age-group"
@@ -11,6 +11,7 @@
         :labels="labels7MA"
         :data-labels="ageLabels"
         :table-labels="ageLabels"
+        :day-period="isSingleCard && $vuetify.breakpoint.mdAndUp ? 120 : 60"
       >
         <template #notes>
           <ul>
@@ -35,6 +36,7 @@ import AgeChart from '@/components/index/CardsMonitoring/AgeGroup/Chart.vue'
 import DailyPositiveDetail from '@/data/daily_positive_detail.json'
 import Data from '@/data/data.json'
 import { getNumberToFixedFunction } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 type DataType = {
   ageLabels: string[] | TranslateResult[]
@@ -48,7 +50,9 @@ type DataType = {
 
 type MethodsType = {}
 
-type ComputedType = {}
+type ComputedType = {
+  isSingleCard: boolean
+}
 
 type PropsType = {}
 
@@ -148,6 +152,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       labels7MA,
       chartData7MA,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 

--- a/components/index/CardsMonitoring/ConfirmedCasesNumber/Card.vue
+++ b/components/index/CardsMonitoring/ConfirmedCasesNumber/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="ConfirmedCasesNumberCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="ConfirmedCasesNumberCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <time-bar-chart
         :title="$t('ConfirmedCasesNumberCard.title')"
@@ -9,6 +14,7 @@
         :date="Data.patients_summary.date"
         :unit="$t('Common.人')"
         :by-date="true"
+        :day-period="isSingleCard && $vuetify.breakpoint.mdAndUp ? 120 : 60"
       />
       <slot name="breadCrumb" />
     </client-only>
@@ -19,6 +25,7 @@
 import TimeBarChart from '@/components/index/_shared/TimeBarChart.vue'
 import Data from '@/data/data.json'
 import formatGraph from '@/utils/formatGraph'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -38,6 +45,11 @@ export default {
       Data,
       patientsGraph,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsMonitoring/EffectiveReproductionNumber/Card.vue
+++ b/components/index/CardsMonitoring/EffectiveReproductionNumber/Card.vue
@@ -2,7 +2,7 @@
   <v-col
     id="EffectiveReproductionNumberCard"
     cols="12"
-    :md="md"
+    :md="isSingleCard || md"
     class="DataCard"
   >
     <client-only>
@@ -16,6 +16,7 @@
         :labels="labels"
         :data-labels="dataLabels"
         :table-labels="tableLabels"
+        :day-period="isSingleCard && $vuetify.breakpoint.mdAndUp ? 120 : 60"
       >
         <template #selectCity>
           <v-select
@@ -64,6 +65,7 @@ import EffectiveReproductionNumberChart from '@/components/index/CardsMonitoring
 import DailyPositiveDetail from '@/data/daily_positive_detail.json'
 import Data from '@/data/data.json'
 import { getNumberToFixedFunction } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 type SelectItem = {
   text: string
@@ -86,6 +88,7 @@ type MethodsType = {
 type ComputedType = {
   labels: string[]
   chartData: number[][]
+  isSingleCard: boolean
 }
 
 type PropsType = {}
@@ -240,6 +243,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     labels() {
       return DailyPositiveDetail.data.map((a) => a.diagnosed_date)
+    },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
   methods: {

--- a/components/index/CardsMonitoring/HealthBurdenHospital/Card.vue
+++ b/components/index/CardsMonitoring/HealthBurdenHospital/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="HealthBurdenHospitalCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="HealthBurdenHospitalCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <health-burden-hospital-chart
         title-id="health-burden-hospital"
@@ -37,6 +42,7 @@ import type { TranslateResult } from 'vue-i18n'
 import AppLink from '@/components/_shared/AppLink.vue'
 import HealthBurdenHospitalChart from '@/components/index/CardsMonitoring/HealthBurdenHospital/Chart.vue'
 import HealthBurden from '@/data/health_burden.json'
+import { isSingleCard } from '@/utils/urls'
 
 type DataType = {
   healthBurdenLabels: string[] | TranslateResult[]
@@ -49,7 +55,9 @@ type DataType = {
 
 type MethodsType = {}
 
-type ComputedType = {}
+type ComputedType = {
+  isSingleCard: boolean
+}
 
 type PropsType = {}
 
@@ -108,6 +116,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       labels,
       chartData,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 

--- a/components/index/CardsMonitoring/HospitalizedNumber/Card.vue
+++ b/components/index/CardsMonitoring/HospitalizedNumber/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="HospitalizedNumberCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="HospitalizedNumberCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <hospitalized-time-stacked-bar-chart
         :title="$t('HospitalizedNumberCard.title')"
@@ -12,6 +17,7 @@
         :unit="$t('Common.人')"
         :data-labels="hospitalizedDataLabels"
         :table-labels="hospitalizedTableLabels"
+        :day-period="isSingleCard && $vuetify.breakpoint.mdAndUp ? 120 : 60"
       >
         <template #notes>
           <table :class="$style.beds">
@@ -103,6 +109,7 @@ import AppLink from '@/components/_shared/AppLink.vue'
 import HospitalizedTimeStackedBarChart from '@/components/index/CardsMonitoring/HospitalizedNumber/Chart.vue'
 import PositiveStatus from '@/data/positive_status.json'
 import { getNumberToLocaleStringFunction } from '@/utils/monitoringStatusValueFormatters.ts'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -149,6 +156,11 @@ export default {
       hospitalizedTableLabels,
       getFormatter,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Card.vue
+++ b/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Card.vue
@@ -2,7 +2,7 @@
   <v-col
     id="MonitoringConfirmedCasesNumberCard"
     cols="12"
-    :md="md"
+    :md="isSingleCard || md"
     class="DataCard"
   >
     <client-only>
@@ -20,6 +20,7 @@
         :data-labels="dataLabels"
         :table-labels="tableLabels"
         :unit="$t('Common.人')"
+        :day-period="isSingleCard && $vuetify.breakpoint.mdAndUp ? 120 : 60"
       >
         <template #notes>
           <ul>
@@ -50,6 +51,7 @@ import {
   getNumberToFixedFunction,
   getNumberToLocaleStringFunction,
 } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -98,6 +100,11 @@ export default {
       tableLabels,
       getFormatter,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsMonitoring/PositiveRate/Card.vue
+++ b/components/index/CardsMonitoring/PositiveRate/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="PositiveRateCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="PositiveRateCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <positive-rate-chart
         :title-id="'positive-rate'"
@@ -16,6 +21,7 @@
         :option-unit="$t('件.reports')"
         :data-labels="positiveRateDataLabels"
         :table-labels="positiveRateTableLabels"
+        :day-period="isSingleCard && $vuetify.breakpoint.mdAndUp ? 120 : 60"
       >
         <template #notes>
           <div :class="$style.newScenario">
@@ -43,6 +49,8 @@ import {
   getNumberToFixedFunction,
   getNumberToLocaleStringFunction,
 } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
+
 extend(duration)
 
 export default {
@@ -105,6 +113,11 @@ export default {
       positiveRateTableLabels,
       getFormatter,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsMonitoring/TestedNumber/Card.vue
+++ b/components/index/CardsMonitoring/TestedNumber/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="TestedNumberCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="TestedNumberCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <time-stacked-bar-chart
         :title="$t('TestedNumberCard.title')"
@@ -12,6 +17,7 @@
         :unit="$t('件.tested')"
         :data-labels="inspectionsDataLabels"
         :table-labels="inspectionsTableLabels"
+        :day-period="isSingleCard && $vuetify.breakpoint.mdAndUp ? 120 : 60"
       >
         <template #notes>
           <ul>
@@ -29,6 +35,7 @@
 <script>
 import TimeStackedBarChart from '@/components/index/_shared/TimeStackedBarChart.vue'
 import PositiveRate from '@/data/positive_rate.json'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -71,6 +78,11 @@ export default {
       inspectionsDataLabels,
       inspectionsTableLabels,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsMonitoring/UntrackedRate/Card.vue
+++ b/components/index/CardsMonitoring/UntrackedRate/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="UntrackedRateCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="UntrackedRateCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <untracked-rate-chart
         :title-id="'untracked-rate'"
@@ -12,6 +17,7 @@
         :unit="[$t('Common.人')]"
         :data-labels="dataLabels"
         :table-labels="tableLabels"
+        :day-period="isSingleCard && $vuetify.breakpoint.mdAndUp ? 120 : 60"
       >
         <template #notes>
           <ul>
@@ -36,6 +42,7 @@ import {
   getNumberToFixedFunction,
   getNumberToLocaleStringFunction,
 } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -85,6 +92,11 @@ export default {
       tableLabels,
       getFormatter,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsReference/ConfirmedCasesAttributes/Card.vue
+++ b/components/index/CardsReference/ConfirmedCasesAttributes/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="ConfirmedCasesAttributesCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="ConfirmedCasesAttributesCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <data-table
         :title="$t('ConfirmedCasesAttributesCard.title')"
@@ -31,6 +36,7 @@ import DataTable from '@/components/index/CardsReference/ConfirmedCasesAttribute
 import Data from '@/data/data.json'
 import { getDayjsObject } from '@/utils/formatDate'
 import formatTable from '@/utils/formatTable'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -114,6 +120,11 @@ export default {
       patientsTable,
       sumInfoOfPatients,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
   methods: {
     getTranslatedWording(value) {

--- a/components/index/CardsReference/ConfirmedCasesByMunicipalities/Card.vue
+++ b/components/index/CardsReference/ConfirmedCasesByMunicipalities/Card.vue
@@ -2,7 +2,7 @@
   <v-col
     id="ConfirmedCasesByMunicipalitiesCard"
     cols="12"
-    :md="md"
+    :md="isSingleCard || md"
     class="DataCard"
   >
     <client-only>
@@ -35,6 +35,7 @@ import dayjs from 'dayjs'
 import ConfirmedCasesByMunicipalitiesTable from '@/components/index/CardsReference/ConfirmedCasesByMunicipalities/Table.vue'
 import Data from '@/data/data.json'
 import PatientMunicipalities from '@/data/patient_municipalities.json'
+import { isSingleCard } from '@/utils/urls'
 
 const population = {
   盛岡市: 289893,
@@ -172,6 +173,11 @@ export default {
       municipalitiesTable,
       info,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsReference/IwateNinshou/Restaurant/Card.vue
+++ b/components/index/CardsReference/IwateNinshou/Restaurant/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="IwateNinshouRestaurantMapCard" cols="12" :md="12" class="DataCard">
+  <v-col
+    id="IwateNinshouRestaurantMapCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <restaurant-map
         :title="$t('RestaurantCard.title')"
@@ -24,6 +29,7 @@ import Vue from 'vue'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 
 import RestaurantMap from '@/components/index/CardsReference/IwateNinshou/Restaurant/Map.vue'
+import { isSingleCard } from '@/utils/urls'
 
 type DataType = {}
 type MethodsType = {}
@@ -44,6 +50,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     md: {
       type: String,
       default: '6',
+    },
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
 }

--- a/components/index/CardsReference/SelfDisclosures/Card.vue
+++ b/components/index/CardsReference/SelfDisclosures/Card.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-col id="SelfDisclosuresCard" cols="12" :md="md" class="DataCard">
+  <v-col
+    id="SelfDisclosuresCard"
+    cols="12"
+    :md="isSingleCard || md"
+    class="DataCard"
+  >
     <client-only>
       <self-disclosures-table
         :title="$t('SelfDisclosuresCard.title')"
@@ -27,6 +32,7 @@ import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import AppLink from '@/components/_shared/AppLink.vue'
 import SelfDisclosuresTable from '@/components/index/CardsReference/SelfDisclosures/Table.vue'
 import SelfDisclosures from '@/data/self_disclosures.json'
+import { isSingleCard } from '@/utils/urls'
 
 type NewsItem = {
   date: string
@@ -40,7 +46,9 @@ type NewsItems = {
 }
 
 type Methods = {}
-type Computed = {}
+type Computed = {
+  isSingleCard: boolean
+}
 type Props = {}
 
 const options: ThisTypedComponentOptionsWithRecordProps<
@@ -99,6 +107,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       newsItems,
       date,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 

--- a/components/index/CardsReference/WhatsNew/Card.vue
+++ b/components/index/CardsReference/WhatsNew/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col id="WhatsNewCard" cols="12" :md="md" class="DataCard">
+  <v-col id="WhatsNewCard" cols="12" :md="isSingleCard || md" class="DataCard">
     <client-only>
       <whats-new-table
         :title="$t('WhatsNewCard.title')"
@@ -18,6 +18,7 @@ import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 
 import WhatsNewTable from '@/components/index/CardsReference/WhatsNew/Table.vue'
 import News from '@/data/news.json'
+import { isSingleCard } from '@/utils/urls'
 
 type NewsItem = {
   date: string
@@ -31,7 +32,9 @@ type NewsItems = {
 }
 
 type Methods = {}
-type Computed = {}
+type Computed = {
+  isSingleCard: boolean
+}
 type Props = {}
 
 const options: ThisTypedComponentOptionsWithRecordProps<
@@ -89,6 +92,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       newsItems,
       date,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -167,6 +167,7 @@ export default {
       case 'confirmed-cases-area':
         cardComponent = 'confirmed-cases-area-card'
         cardTitle = this.$t('ConfirmedCasesAreaCard.title')
+        break
       case 'health-burden-hospital':
         cardComponent = 'health-burden-hospital-card'
         cardTitle = this.$t('HealthBurdenHospitalCard.title')

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -1,3 +1,7 @@
 export function isExternal(path: string): boolean {
   return /^https?:\/\//.test(path) || /^extUrl/.test(path)
 }
+
+export function isSingleCard(path: string): boolean {
+  return path.startsWith('/cards/')
+}


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2751 

## 📝 関連する issue / Related Issues
- https://github.com/tokyo-metropolitan-gov/covid19/pull/6599

## ⛏ 変更内容 / Details of Changes
- カード単体表示 かつ breakpoint.mdAndUp (タブレット横以上)のときグラフの初期表示期間を２倍（120日分）にする

