### PR TITLE
scaledTicksYAxisMax の値を調整

### DIFF
--- a/components/index/CardsFeatured/MonitoringConfirmedCasesNumberPer100k/Chart.vue
+++ b/components/index/CardsFeatured/MonitoringConfirmedCasesNumberPer100k/Chart.vue
@@ -428,7 +428,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         0
       )
       const digits = String(Math.ceil(max)).length
-      const base = 10 ** (digits - 1)
+      const base = 10 ** (digits - 2)
       return Math.ceil(max / base) * base
     },
     startDateIndex() {

--- a/components/index/CardsMonitoring/AgeGroup/Chart.vue
+++ b/components/index/CardsMonitoring/AgeGroup/Chart.vue
@@ -376,7 +376,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         0
       )
       const digits = String(Math.ceil(max)).length
-      const base = 10 ** (digits - 1)
+      const base = 10 ** (digits - 2)
       return Math.ceil(max / base) * base
     },
     startDateIndex() {

--- a/components/index/CardsMonitoring/EffectiveReproductionNumber/Chart.vue
+++ b/components/index/CardsMonitoring/EffectiveReproductionNumber/Chart.vue
@@ -380,10 +380,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return options
     },
     scaledTicksYAxisMax() {
-      // return this.chartData.reduce((max, data) => {
-      //   return Math.max(max, ...data.map((a) => Math.ceil(a))) + 10
-      // }, 0)
-      return 5
+      return 2
     },
     startDateIndex() {
       const searchIndex = this.labels.findIndex((item) => {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #3099 

## ⛏ 変更内容 / Details of Changes
- グラフの縦軸の max の値を調整して見やすくする
